### PR TITLE
Add PersuaBot implementation based on arXiv:2407.03585

### DIFF
--- a/PERSUABOT.md
+++ b/PERSUABOT.md
@@ -1,0 +1,251 @@
+# PersuaBot
+
+PersuaBot is a zero-shot persuasive chatbot with LLM-generated strategies and information retrieval, based on the paper:
+
+**"Zero-shot Persuasive Chatbots with LLM-Generated Strategies and Information Retrieval"**
+Kazuaki Furumai, Roberto Legaspi, Julio Vizcarra, Yudai Yamazaki, Yasutaka Nishimura, Sina J. Semnani, Kazushi Ikeda, Weiyan Shi, and Monica S. Lam
+arXiv:2407.03585 (2024)
+
+## Overview
+
+PersuaBot addresses a major limitation of prior persuasive chatbot approaches: existing methods rely on fine-tuning with task-specific training data which is costly to collect, and they employ only a handful of pre-defined persuasion strategies.
+
+PersuaBot is a **multi-step pipeline of LLM calls with in-context learning** that:
+- Generates persuasive responses using diverse, dynamically-generated strategies
+- Ensures factual correctness through systematic fact-checking
+- Retrieves factual information to substantiate claims
+- Works in a zero-shot manner without requiring domain-specific training data
+
+## Architecture
+
+PersuaBot consists of two parallel modules that work together:
+
+### 1. Question Handling Module (QHM)
+The QHM handles direct user questions by:
+- Identifying when the user asks for factual information
+- Generating appropriate search queries
+- Retrieving relevant information from the corpus
+
+### 2. Strategy Maintenance Module (SMM)
+The SMM is the core of PersuaBot's persuasive capabilities:
+
+1. **Response Generation**: Generates an initial persuasive response using various strategies
+2. **Strategy Decomposition**: Breaks down the response into sections, each with a distinct persuasion strategy
+3. **Fact-Checking**: Verifies each section for factual accuracy
+4. **Information Retrieval**: For unverified sections, retrieves factual information from the corpus
+5. **Result Merging**: Combines persuasion strategies with factual information to create the final response
+
+### Key Concept
+
+The key innovation is to **separate persuasion strategies from factual content**:
+- Keep the persuasive intent and strategies
+- Replace LLM-generated claims with verified facts when needed
+- Ensure both persuasiveness and factual accuracy
+
+## Installation
+
+PersuaBot is built on top of the WikiChat framework and uses the same dependencies. Follow the WikiChat installation instructions in the main [README.md](README.md).
+
+## Usage
+
+### Basic Usage
+
+Run PersuaBot with default settings:
+
+```bash
+python -m command_line_persuabot --engine gpt-4o
+```
+
+### Specify Persuasion Domain and Goal
+
+PersuaBot can be customized for different persuasion scenarios:
+
+```bash
+# Donation solicitation
+python -m command_line_persuabot \
+  --engine gpt-4o \
+  --persuasion_domain "donation" \
+  --target_goal "encourage donation to education charities"
+
+# Health intervention
+python -m command_line_persuabot \
+  --engine gpt-4o \
+  --persuasion_domain "health" \
+  --target_goal "encourage healthier lifestyle choices"
+
+# Recommendation
+python -m command_line_persuabot \
+  --engine gpt-4o \
+  --persuasion_domain "recommendation" \
+  --target_goal "recommend books similar to user preferences"
+```
+
+### Advanced Options
+
+```bash
+# Disable fact-checking (faster but less accurate)
+python -m command_line_persuabot \
+  --engine gpt-4o \
+  --no_fact_checking
+
+# Disable strategy decomposition (treats response as single unit)
+python -m command_line_persuabot \
+  --engine gpt-4o \
+  --no_strategy_decomposition
+
+# Enable debug mode to see strategy breakdown
+python -m command_line_persuabot \
+  --engine gpt-4o \
+  --debug
+```
+
+### Retrieval Configuration
+
+PersuaBot uses the same retrieval system as WikiChat:
+
+```bash
+# Use default Wikipedia API (rate-limited)
+python -m command_line_persuabot --engine gpt-4o
+
+# Use custom corpus
+python -m command_line_persuabot \
+  --engine gpt-4o \
+  --corpus_id "my_corpus" \
+  --retriever_endpoint "http://localhost:5100/my_collection"
+```
+
+### All Available Options
+
+```bash
+python -m command_line_persuabot --help
+```
+
+Key parameters:
+- `--engine`: LLM to use (default: gpt-4o)
+- `--persuasion_domain`: Domain for persuasion (e.g., 'donation', 'health', 'recommendation')
+- `--target_goal`: Specific persuasion goal
+- `--do_fact_checking` / `--no_fact_checking`: Enable/disable fact-checking (default: enabled)
+- `--do_strategy_decomposition` / `--no_strategy_decomposition`: Enable/disable strategy decomposition (default: enabled)
+- `--debug`: Show strategy breakdown for each response
+- `--corpus_id`: ID of the corpus to use
+- `--retriever_endpoint`: Endpoint for information retrieval
+- `--do_reranking`: Enable reranking of search results
+- `--query_post_reranking_num`: Number of documents to retrieve for user queries
+- `--claim_post_reranking_num`: Number of evidences per claim
+
+## Example Conversations
+
+### Donation Solicitation
+
+```
+User: I'm thinking about donating to charity.
+PersuaBot: That's wonderful! Donating to charity can make a real difference...
+[Uses social proof, statistics, and authority to encourage donation while ensuring all claims are fact-checked]
+```
+
+### Health Intervention
+
+```
+User: I've been feeling really tired lately.
+PersuaBot: I'm sorry to hear that. According to the CDC, about 35% of adults...
+[Provides fact-checked health information using persuasive strategies]
+```
+
+### Recommendation
+
+```
+User: I just finished The Hunger Games. Any recommendations?
+PersuaBot: If you enjoyed The Hunger Games, you might like The Maze Runner series...
+[Uses ratings, sales figures, and social proof to recommend books]
+```
+
+## Implementation Details
+
+### File Structure
+
+```
+WikiChat/
+├── pipelines/
+│   ├── persuabot.py                  # Main PersuaBot pipeline
+│   ├── persuabot_dialogue_state.py   # State management for PersuaBot
+│   └── prompts/
+│       └── persuabot/
+│           ├── qhm_query.prompt          # QHM query generation
+│           ├── smm_generate.prompt       # SMM response generation
+│           ├── smm_decompose.prompt      # Strategy decomposition
+│           ├── smm_fact_check.prompt     # Fact-checking
+│           ├── smm_generate_query.prompt # Query generation for retrieval
+│           └── smm_merge.prompt          # Merge strategies with facts
+├── command_line_persuabot.py         # Command-line interface
+└── PERSUABOT.md                      # This file
+```
+
+### Pipeline Stages
+
+1. **QHM Query Stage**: Generates search queries from user questions
+2. **QHM Search Stage**: Retrieves information for user queries
+3. **SMM Generate Response**: Creates initial persuasive response
+4. **SMM Decompose Strategies**: Breaks response into strategy sections
+5. **SMM Fact Check**: Verifies factual accuracy of each section
+6. **SMM Retrieve Facts**: Gets factual information for unverified sections
+7. **SMM Merge Results**: Combines strategies with facts to create final response
+
+## Persuasion Strategies
+
+PersuaBot can dynamically employ various persuasion strategies, including:
+
+- **Statistics**: Using numbers and data to support claims
+- **Social Proof**: Referencing what others do or believe
+- **Authority**: Citing expert opinions or authoritative sources
+- **Emotional Appeal**: Connecting with emotions
+- **Scarcity**: Highlighting limited availability or urgency
+- **Reciprocity**: Creating a sense of mutual benefit
+- **Comparison**: Comparing options or alternatives
+- **Storytelling**: Using narratives and examples
+- **Expert Testimony**: Quoting or referencing experts
+- **Logical Reasoning**: Using rational arguments
+
+The chatbot automatically selects and combines appropriate strategies based on the conversation context.
+
+## Performance
+
+According to the paper, PersuaBot:
+- Achieves up to **26.6% higher factuality** than GPT-3.5
+- Has an advantage of **0.6 points on a 5-point persuasiveness scale** compared to manually designed rule-oriented methods
+- Works across multiple domains: donation solicitation, recommendation systems, and healthcare intervention
+
+## Citation
+
+If you use PersuaBot in your research, please cite:
+
+```bibtex
+@article{furumai2024persuabot,
+  title={Zero-shot Persuasive Chatbots with LLM-Generated Strategies and Information Retrieval},
+  author={Furumai, Kazuaki and Legaspi, Roberto and Vizcarra, Julio and
+          Yamazaki, Yudai and Nishimura, Yasutaka and Semnani, Sina J. and
+          Ikeda, Kazushi and Shi, Weiyan and Lam, Monica S.},
+  journal={arXiv preprint arXiv:2407.03585},
+  year={2024}
+}
+```
+
+## Differences from WikiChat
+
+While PersuaBot is built on the WikiChat framework, it has several key differences:
+
+| Feature | WikiChat | PersuaBot |
+|---------|----------|-----------|
+| **Purpose** | Factual, informative conversations | Persuasive conversations with factual grounding |
+| **Response Style** | Neutral, informative | Persuasive, engaging |
+| **Strategy** | Fact-checking claims | Generating + fact-checking persuasive strategies |
+| **Modules** | Single pipeline | Dual modules (QHM + SMM) |
+| **Strategy Decomposition** | N/A | Decomposes response by persuasion strategies |
+| **Use Cases** | Information seeking | Donation, health, recommendations, persuasion |
+
+## License
+
+PersuaBot code is released under Apache-2.0 license, consistent with the WikiChat repository.
+
+## Acknowledgments
+
+PersuaBot is implemented based on the paper by Furumai et al. (2024) and uses the WikiChat framework developed by Stanford OVAL Lab.

--- a/command_line_persuabot.py
+++ b/command_line_persuabot.py
@@ -1,0 +1,142 @@
+"""
+Chat with PersuaBot via command line
+
+This script allows users to interact with PersuaBot, a persuasive chatbot
+based on the paper "Zero-shot Persuasive Chatbots with LLM-Generated
+Strategies and Information Retrieval" (Furumai et al., 2024).
+
+PersuaBot uses a two-module architecture:
+- Question Handling Module (QHM): Retrieves information based on user requests
+- Strategy Maintenance Module (SMM): Generates persuasive responses with fact-checking
+"""
+
+import argparse
+import asyncio
+import json
+
+from chainlite import get_total_cost, write_prompt_logs_to_file
+from utils.logging import logger
+
+from pipelines.persuabot import create_persuabot_chain
+from pipelines.persuabot_dialogue_state import PersuaBotTurn
+from pipelines.pipeline_arguments import (
+    add_pipeline_arguments,
+    check_pipeline_arguments,
+)
+from pipelines.utils import input_user, print_chatbot_response
+
+
+async def main(args):
+    # Create the PersuaBot chatbot and initialize the dialogue state
+    persuabot, dialogue_state = create_persuabot_chain(args)
+
+    logger.info("=" * 80)
+    logger.info("PersuaBot - Persuasive Chatbot with Fact-Checking")
+    logger.info("=" * 80)
+    logger.info(f"Domain: {args.persuasion_domain}")
+    logger.info(f"Goal: {args.target_goal}")
+    logger.info("=" * 80)
+
+    # Main loop to process user inputs
+    while True:
+        try:
+            # Get input from the user via the command line
+            new_user_utterance = input_user()
+        except EOFError:
+            break
+
+        # Check if the input matches any of the pre-defined quit commands
+        if new_user_utterance in args.quit_commands:
+            break
+
+        # Append the new user utterance as a dialogue turn
+        dialogue_state.turns.append(PersuaBotTurn(user_utterance=new_user_utterance))
+
+        # Invoke PersuaBot with the updated dialogue state
+        await persuabot.ainvoke(dialogue_state)
+
+        # Print the chatbot's response
+        print_chatbot_response(dialogue_state.current_turn)
+
+        # Optionally print strategy information in debug mode
+        if args.debug:
+            print("\n[DEBUG] Strategy Breakdown:")
+            for i, section in enumerate(dialogue_state.current_turn.smm_sections, 1):
+                print(f"  Section {i}: {section.strategy}")
+                print(f"    Factual: {section.is_factual}")
+                if section.retrieval_query:
+                    print(f"    Retrieved using: {section.retrieval_query}")
+            print()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="PersuaBot: Persuasive chatbot with fact-checking"
+    )
+    add_pipeline_arguments(parser)
+
+    # PersuaBot-specific arguments
+    parser.add_argument(
+        "--persuasion_domain",
+        type=str,
+        default="general",
+        help="The domain for persuasion (e.g., 'donation', 'health', 'recommendation')",
+    )
+    parser.add_argument(
+        "--target_goal",
+        type=str,
+        default="have a helpful and persuasive conversation",
+        help="The specific persuasion goal",
+    )
+    parser.add_argument(
+        "--do_fact_checking",
+        action="store_true",
+        default=True,
+        help="Whether to perform fact-checking on generated content",
+    )
+    parser.add_argument(
+        "--no_fact_checking",
+        dest="do_fact_checking",
+        action="store_false",
+        help="Disable fact-checking",
+    )
+    parser.add_argument(
+        "--do_strategy_decomposition",
+        action="store_true",
+        default=True,
+        help="Whether to decompose response into strategy sections",
+    )
+    parser.add_argument(
+        "--no_strategy_decomposition",
+        dest="do_strategy_decomposition",
+        action="store_false",
+        help="Disable strategy decomposition",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        default=False,
+        help="Show strategy breakdown for each response",
+    )
+    parser.add_argument(
+        "--quit_commands",
+        type=str,
+        default=["quit", "q", "Exit", "exit"],
+        help="The conversation will continue until this string is typed in.",
+    )
+
+    args = parser.parse_args()
+    check_pipeline_arguments(args)
+
+    logger.info(
+        f"Starting PersuaBot with arguments: {json.dumps(vars(args), ensure_ascii=False, indent=2)}"
+    )
+
+    # Run the main asynchronous function to start the chatbot session
+    asyncio.run(main(args))
+
+    # Log the total cost of LLM usage at the end of the session
+    logger.info(f"Total LLM cost: ${get_total_cost():.2f}")
+
+    # Write the inputs and outputs of each individual prompt to a file
+    write_prompt_logs_to_file()

--- a/pipelines/persuabot.py
+++ b/pipelines/persuabot.py
@@ -1,0 +1,340 @@
+"""
+PersuaBot: Zero-shot Persuasive Chatbot with LLM-Generated Strategies and Information Retrieval
+
+Based on the paper:
+"Zero-shot Persuasive Chatbots with LLM-Generated Strategies and Information Retrieval"
+Furumai et al., 2024 (arXiv:2407.03585)
+
+This implementation follows the paper's two-module architecture:
+1. Question Handling Module (QHM): Retrieves information based on user requests
+2. Strategy Maintenance Module (SMM): Generates persuasive responses with fact-checking
+"""
+
+import json
+
+from chainlite import chain, llm_generation_chain, register_prompt_constants
+from chainlite.llm_output import extract_tag_from_llm_output, lines_to_list
+from langgraph.graph.state import CompiledStateGraph
+from langgraph.graph import END, START, StateGraph
+
+from corpora import corpus_id_to_corpus_object
+from utils.logging import logger
+from pipelines.persuabot_dialogue_state import (
+    PersuaBotConfig,
+    PersuaBotState,
+    PersuaBotSection,
+)
+from retrieval.retriever_api import retrieve_via_api
+
+register_prompt_constants({"chatbot_name": "PersuaBot"})
+
+
+# ============================================================================
+# Question Handling Module (QHM)
+# ============================================================================
+
+
+@chain
+async def qhm_query_stage(state: PersuaBotState):
+    """Generate search queries based on user's explicit questions."""
+    query_chain = (
+        llm_generation_chain(
+            "persuabot/qhm_query.prompt", engine=state.config.engine, max_tokens=200
+        )
+        | extract_tag_from_llm_output.bind(tags="search_query")  # type: ignore
+        | lines_to_list
+    )
+    search_queries = await query_chain.ainvoke(
+        {"dlg": state, "llm_corpus_description": state.config.llm_corpus_description}
+    )
+    search_queries = [q for q in search_queries if q and q != "None"]
+
+    if not search_queries:
+        logger.info("QHM: No search needed for user question.")
+        state.current_turn.qhm_query = []
+        return
+
+    logger.info(f"QHM queries: {json.dumps(search_queries, ensure_ascii=False)}")
+    state.current_turn.qhm_query = search_queries
+
+
+@chain
+async def qhm_search_stage(state: PersuaBotState):
+    """Retrieve information based on user queries."""
+    queries = state.current_turn.qhm_query
+    if not queries:
+        return
+
+    try:
+        search_results = retrieve_via_api(
+            queries,
+            retriever_endpoint=state.config.retriever_endpoint,
+            do_reranking=state.config.do_reranking,
+            pre_reranking_num=state.config.query_pre_reranking_num,
+            post_reranking_num=state.config.query_post_reranking_num,
+        )
+        state.current_turn.qhm_search_results = search_results
+        logger.info(f"QHM: Retrieved {len(search_results)} result sets")
+    except Exception as e:
+        logger.error(f"QHM search error: {e}")
+        state.current_turn.qhm_search_results = []
+
+
+# ============================================================================
+# Strategy Maintenance Module (SMM)
+# ============================================================================
+
+
+@chain
+async def smm_generate_response(state: PersuaBotState):
+    """Generate initial persuasive response with strategies."""
+    generate_chain = (
+        llm_generation_chain(
+            "persuabot/smm_generate.prompt", engine=state.config.engine, max_tokens=2000
+        )
+        | extract_tag_from_llm_output.bind(tags="response")  # type: ignore
+    )
+
+    response = await generate_chain.ainvoke(
+        {
+            "dlg": state,
+            "persuasion_domain": state.config.persuasion_domain,
+            "target_goal": state.config.target_goal,
+        }
+    )
+
+    if not response or response == "None":
+        logger.warning("SMM: Generated empty response")
+        return
+
+    state.current_turn.smm_initial_response = response
+    logger.info(f"SMM: Generated initial response ({len(response)} chars)")
+
+
+@chain
+async def smm_decompose_strategies(state: PersuaBotState):
+    """Decompose response into sections with distinct strategies."""
+    if not state.config.do_strategy_decomposition:
+        # Skip decomposition, treat entire response as one section
+        if state.current_turn.smm_initial_response:
+            section = PersuaBotSection(
+                content=state.current_turn.smm_initial_response,
+                strategy="general persuasion",
+            )
+            state.current_turn.smm_sections = [section]
+        return
+
+    decompose_chain = llm_generation_chain(
+        "persuabot/smm_decompose.prompt", engine=state.config.engine, max_tokens=2000
+    )
+
+    decomposed = await decompose_chain.ainvoke(
+        {"dlg": state, "response": state.current_turn.smm_initial_response}
+    )
+
+    # Parse the decomposed output into sections
+    # Expected format: <section strategy="...">content</section>
+    sections = []
+    import re
+
+    pattern = r'<section strategy="([^"]*)">(.*?)</section>'
+    matches = re.findall(pattern, decomposed, re.DOTALL)
+
+    for strategy, content in matches:
+        section = PersuaBotSection(
+            content=content.strip(), strategy=strategy.strip()
+        )
+        sections.append(section)
+
+    if not sections:
+        # Fallback: treat entire response as one section
+        logger.warning("SMM: Could not parse sections, using entire response")
+        section = PersuaBotSection(
+            content=state.current_turn.smm_initial_response or "",
+            strategy="general persuasion",
+        )
+        sections = [section]
+
+    state.current_turn.smm_sections = sections
+    logger.info(f"SMM: Decomposed into {len(sections)} strategy sections")
+
+
+@chain
+async def smm_fact_check(state: PersuaBotState):
+    """Fact-check each section of the response."""
+    if not state.config.do_fact_checking:
+        # Mark all sections as factual
+        for section in state.current_turn.smm_sections:
+            section.is_factual = True
+        return
+
+    fact_check_chain = (
+        llm_generation_chain(
+            "persuabot/smm_fact_check.prompt",
+            engine=state.config.engine,
+            max_tokens=500,
+        )
+        | extract_tag_from_llm_output.bind(tags="verdict")  # type: ignore
+    )
+
+    # Fact-check each section in parallel
+    verdicts = await fact_check_chain.abatch(
+        [{"dlg": state, "section": section} for section in state.current_turn.smm_sections]
+    )
+
+    factual_count = 0
+    for section, verdict in zip(state.current_turn.smm_sections, verdicts):
+        section.is_factual = verdict.strip().lower() in ["true", "factual", "verified"]
+        if section.is_factual:
+            factual_count += 1
+
+    logger.info(
+        f"SMM: Fact-checking complete - {factual_count}/{len(state.current_turn.smm_sections)} sections verified"
+    )
+
+
+@chain
+async def smm_retrieve_facts(state: PersuaBotState):
+    """For unsubstantiated sections, generate queries and retrieve facts."""
+    unverified_sections = [
+        s for s in state.current_turn.smm_sections if not s.is_factual
+    ]
+
+    if not unverified_sections:
+        logger.info("SMM: All sections are factual, no retrieval needed")
+        return
+
+    # Generate retrieval queries for unverified sections
+    query_chain = (
+        llm_generation_chain(
+            "persuabot/smm_generate_query.prompt",
+            engine=state.config.engine,
+            max_tokens=200,
+        )
+        | extract_tag_from_llm_output.bind(tags="query")  # type: ignore
+    )
+
+    queries = await query_chain.abatch(
+        [{"dlg": state, "section": section} for section in unverified_sections]
+    )
+
+    # Clean queries
+    queries = [q.strip() for q in queries if q and q.strip() != "None"]
+
+    if not queries:
+        logger.info("SMM: No retrieval queries generated")
+        return
+
+    logger.info(f"SMM: Generated {len(queries)} retrieval queries")
+
+    # Retrieve facts
+    try:
+        search_results = retrieve_via_api(
+            queries,
+            retriever_endpoint=state.config.retriever_endpoint,
+            do_reranking=state.config.do_reranking,
+            pre_reranking_num=state.config.claim_pre_reranking_num,
+            post_reranking_num=state.config.claim_post_reranking_num,
+        )
+
+        # Attach results to sections
+        for section, query, results in zip(unverified_sections, queries, search_results):
+            section.retrieval_query = query
+            section.retrieved_facts = results.results
+
+        logger.info(f"SMM: Retrieved facts for {len(queries)} sections")
+    except Exception as e:
+        logger.error(f"SMM: Error retrieving facts: {e}")
+
+
+@chain
+async def smm_merge_results(state: PersuaBotState):
+    """Merge retrieved facts with strategies to create final response."""
+    merge_chain = (
+        llm_generation_chain(
+            "persuabot/smm_merge.prompt", engine=state.config.engine, max_tokens=2000
+        )
+        | extract_tag_from_llm_output.bind(tags="response")  # type: ignore
+    )
+
+    # Prepare all sections with their facts
+    final_response = await merge_chain.ainvoke(
+        {
+            "dlg": state,
+            "sections": state.current_turn.smm_sections,
+            "qhm_results": state.current_turn.qhm_search_results,
+            "persuasion_domain": state.config.persuasion_domain,
+            "target_goal": state.config.target_goal,
+        }
+    )
+
+    state.current_turn.smm_final_response = final_response
+    logger.info(f"SMM: Generated final response ({len(final_response)} chars)")
+
+
+# ============================================================================
+# Graph Construction
+# ============================================================================
+
+
+def create_persuabot_chain(args) -> tuple[CompiledStateGraph, PersuaBotState]:
+    """Create the PersuaBot pipeline graph."""
+
+    llm_corpus_description = corpus_id_to_corpus_object(
+        args.corpus_id
+    ).llm_corpus_description
+
+    initial_state = PersuaBotState(
+        turns=[],
+        config=PersuaBotConfig(
+            engine=args.engine,
+            do_refine=False,  # PersuaBot doesn't use refine stage
+            llm_corpus_description=llm_corpus_description,
+            retriever_endpoint=args.retriever_endpoint,
+            do_reranking=args.do_reranking,
+            query_pre_reranking_num=args.query_pre_reranking_num,
+            query_post_reranking_num=args.query_post_reranking_num,
+            claim_pre_reranking_num=args.claim_pre_reranking_num,
+            claim_post_reranking_num=args.claim_post_reranking_num,
+            # PersuaBot-specific config
+            persuasion_domain=getattr(args, "persuasion_domain", "general"),
+            target_goal=getattr(
+                args, "target_goal", "have a helpful and persuasive conversation"
+            ),
+            do_fact_checking=getattr(args, "do_fact_checking", True),
+            do_strategy_decomposition=getattr(args, "do_strategy_decomposition", True),
+        ),
+    )
+
+    graph = StateGraph(PersuaBotState)
+
+    # Add QHM nodes
+    graph.add_node("qhm_query_stage", qhm_query_stage)
+    graph.add_node("qhm_search_stage", qhm_search_stage)
+
+    # Add SMM nodes
+    graph.add_node("smm_generate_response", smm_generate_response)
+    graph.add_node("smm_decompose_strategies", smm_decompose_strategies)
+    graph.add_node("smm_fact_check", smm_fact_check)
+    graph.add_node("smm_retrieve_facts", smm_retrieve_facts)
+    graph.add_node("smm_merge_results", smm_merge_results)
+
+    # QHM pipeline (runs in parallel with SMM initially)
+    graph.add_edge(START, "qhm_query_stage")
+    graph.add_edge("qhm_query_stage", "qhm_search_stage")
+
+    # SMM pipeline
+    graph.add_edge(START, "smm_generate_response")
+    graph.add_edge("smm_generate_response", "smm_decompose_strategies")
+    graph.add_edge("smm_decompose_strategies", "smm_fact_check")
+    graph.add_edge("smm_fact_check", "smm_retrieve_facts")
+
+    # Both QHM and SMM converge at merge stage
+    graph.add_edge("qhm_search_stage", "smm_merge_results")
+    graph.add_edge("smm_retrieve_facts", "smm_merge_results")
+
+    graph.add_edge("smm_merge_results", END)
+
+    runnable = graph.compile()
+
+    return runnable, initial_state

--- a/pipelines/persuabot_dialogue_state.py
+++ b/pipelines/persuabot_dialogue_state.py
@@ -1,0 +1,86 @@
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+from pipelines.dialogue_state import (
+    DialogueTurn,
+    DialogueState,
+    ChatbotConfig,
+)
+from retrieval.retrieval_commons import QueryResult, SearchResultBlock
+
+
+class PersuaBotSection(BaseModel):
+    """A section of the response with its persuasion strategy and fact-check status."""
+
+    content: str = Field(..., description="The content of this section")
+    strategy: Optional[str] = Field(
+        None, description="The persuasion strategy used in this section"
+    )
+    is_factual: bool = Field(
+        default=False, description="Whether this section passed fact-checking"
+    )
+    retrieval_query: Optional[str] = Field(
+        None, description="Query to retrieve factual information for this section"
+    )
+    retrieved_facts: list[SearchResultBlock] = Field(
+        default_factory=list,
+        description="Retrieved factual information for this section",
+    )
+
+
+class PersuaBotTurn(DialogueTurn):
+    """Extended dialogue turn for PersuaBot with strategy maintenance fields."""
+
+    # Question Handling Module (QHM) fields
+    qhm_query: list[str] = []
+    qhm_search_results: list[QueryResult] = []
+
+    # Strategy Maintenance Module (SMM) fields
+    smm_initial_response: Optional[str] = None
+    smm_sections: list[PersuaBotSection] = []
+    smm_final_response: Optional[str] = None
+
+    # Override the agent_utterance to use SMM final response
+    @property
+    def agent_utterance(self) -> Optional[str]:
+        if self.smm_final_response:
+            return self.smm_final_response
+        return self._agent_utterance
+
+    @agent_utterance.setter
+    def agent_utterance(self, value: Optional[str]):
+        self._agent_utterance = value
+
+    _agent_utterance: Optional[str] = None
+
+
+class PersuaBotConfig(ChatbotConfig):
+    """Configuration for PersuaBot."""
+
+    persuasion_domain: str = Field(
+        default="general",
+        description="The domain for persuasion (e.g., 'donation', 'health', 'recommendation')",
+    )
+    target_goal: str = Field(
+        default="persuade the user",
+        description="The specific persuasion goal (e.g., 'encourage donation to charity X')",
+    )
+    do_fact_checking: bool = Field(
+        default=True, description="Whether to perform fact-checking on generated content"
+    )
+    do_strategy_decomposition: bool = Field(
+        default=True,
+        description="Whether to decompose response into strategy sections",
+    )
+
+
+class PersuaBotState(DialogueState):
+    """Dialogue state for PersuaBot."""
+
+    config: PersuaBotConfig
+    turns: list[PersuaBotTurn]
+
+    @property
+    def current_turn(self) -> PersuaBotTurn:
+        return self.turns[-1]

--- a/pipelines/prompts/persuabot/qhm_query.prompt
+++ b/pipelines/prompts/persuabot/qhm_query.prompt
@@ -1,0 +1,78 @@
+# instruction
+You are an AI assistant in a persuasive chatbot system. Your role is to identify when the user is asking a direct question that requires factual information retrieval.
+
+Today's date is {{ today }}.
+
+Analyze the user's input to determine if they are asking a question that requires searching the corpus for factual information.
+
+Generate search queries ONLY for:
+- Direct questions asking for information
+- Requests for facts or explanations
+- Questions about specific topics, people, places, or events
+
+Do NOT generate queries for:
+- Casual conversation
+- Opinions or preferences
+- Acknowledgments or reactions
+- Questions about the chatbot itself
+
+Respond in the following format:
+
+<search_query>
+[The search query or queries to be used. If multiple queries are needed, separate them with a newline. If no search is needed, say "None".]
+</search_query>
+
+
+# distillation instruction
+What factual information should you search for? Today's date is {{ today }}.
+
+
+# input
+Corpus: {{ llm_corpus_description }}
+User: Can you tell me about climate change?
+
+# output
+<search_query>
+climate change causes and effects
+climate change scientific consensus
+climate change global warming
+</search_query>
+
+
+# input
+Corpus: {{ llm_corpus_description }}
+User: I'm thinking about donating to charity.
+Chatbot: That's wonderful! Donating to charity can make a real difference in people's lives. What kind of cause are you interested in supporting?
+User: I'm not sure, maybe something related to education?
+
+# output
+<search_query>
+education charities effectiveness
+education charity programs impact
+</search_query>
+
+
+# input
+Corpus: {{ llm_corpus_description }}
+User: I don't think I can afford to donate right now.
+
+# output
+<search_query>
+None
+</search_query>
+
+
+# input
+Corpus: {{ llm_corpus_description }}
+User: That's interesting, tell me more.
+
+# output
+<search_query>
+None
+</search_query>
+
+
+{# The history of the conversation excluding the current turn. User starts first. #}
+# input
+Corpus: {{ llm_corpus_description }}
+{{ dlg.history(num_turns=1) }}

--- a/pipelines/prompts/persuabot/smm_decompose.prompt
+++ b/pipelines/prompts/persuabot/smm_decompose.prompt
@@ -1,0 +1,24 @@
+# instruction
+You are analyzing a persuasive response to identify distinct sections, each employing a specific persuasion strategy or serving a distinct rhetorical purpose.
+
+Your task is to break down the response into sections where each section:
+1. Uses a distinct persuasion strategy (e.g., "statistics", "social proof", "authority", "emotional appeal", "scarcity", "reciprocity", "comparison", "storytelling", "expert testimony", "logical reasoning")
+2. Makes a coherent point or claim
+3. Can be fact-checked independently
+
+For each section, identify:
+- The specific persuasion strategy being used
+- The content of that section
+
+Output format:
+<section strategy="[strategy name]">
+[section content]
+</section>
+
+Repeat for each distinct section.
+
+
+# input
+Response: {{ response }}
+
+# output

--- a/pipelines/prompts/persuabot/smm_fact_check.prompt
+++ b/pipelines/prompts/persuabot/smm_fact_check.prompt
@@ -1,0 +1,63 @@
+# instruction
+You are a fact-checker analyzing whether a section of text contains factual claims that can be verified.
+
+Your task is to determine if the section makes specific, verifiable factual claims (statistics, dates, names, events, research findings, etc.) that are presented as true.
+
+A section is factual if:
+- It makes specific claims with numbers, dates, or named entities
+- These claims can potentially be verified against reliable sources
+- The claims appear to be accurate based on your knowledge
+
+A section is NOT automatically factual if:
+- It makes vague or general statements
+- It expresses opinions or predictions
+- It asks questions without making claims
+- It makes specific claims that you know to be false or cannot verify
+
+Today's date is {{ today }}. Claims about events or data after your knowledge cutoff should be marked as unverifiable.
+
+Respond with only:
+- "true" if the section contains verifiable factual claims that appear accurate
+- "false" if the section contains claims that cannot be verified, appear inaccurate, or makes no specific factual claims
+
+
+# input
+Section: According to UNESCO, 258 million children and youth worldwide are out of school. Organizations like Room to Read and the Malala Fund have helped millions of children gain access to quality education in developing countries.
+
+# output
+<verdict>
+true
+</verdict>
+
+
+# input
+Section: Many people who've made these changes report feeling more energetic within just 2-3 weeks.
+
+# output
+<verdict>
+false
+</verdict>
+
+
+# input
+Section: The series has a 4.0+ rating on Goodreads with over 2 million reviews.
+
+# output
+<verdict>
+true
+</verdict>
+
+
+# input
+Section: Would you like to know more about specific education charities that are highly rated by organizations like Charity Navigator?
+
+# output
+<verdict>
+false
+</verdict>
+
+
+# input
+Section: {{ section.content }}
+
+# output

--- a/pipelines/prompts/persuabot/smm_generate.prompt
+++ b/pipelines/prompts/persuabot/smm_generate.prompt
@@ -1,0 +1,74 @@
+# instruction
+You are a persuasive chatbot designed to engage users in a convincing and compelling manner while being helpful and informative.
+
+Your goal: {{ target_goal }}
+Domain: {{ persuasion_domain }}
+Today's date is {{ today }}.
+
+Generate a persuasive response that:
+1. Uses appropriate persuasion strategies (e.g., social proof, authority, scarcity, reciprocity, consistency, liking)
+2. Is engaging and conversational
+3. Addresses the user's input directly
+4. Makes claims that can be fact-checked (avoid vague statements)
+5. Maintains a helpful and friendly tone
+
+Important guidelines:
+- Use specific facts and statistics when making claims
+- Employ rhetorical techniques naturally
+- Build trust through credibility
+- Address potential objections
+- Use storytelling or examples when appropriate
+- Be empathetic and understanding
+
+Respond in the following format:
+
+<response>
+[Your persuasive response here]
+</response>
+
+
+# distillation instruction
+Generate a persuasive response. Goal: {{ target_goal }}. Today's date is {{ today }}.
+
+
+# input
+Domain: donation
+Goal: encourage donation to education charities
+User: I'm thinking about donating to charity, maybe something related to education?
+
+# output
+<response>
+That's a wonderful idea! Education charities can have a tremendous impact. Did you know that according to UNESCO, 258 million children and youth worldwide are out of school? Organizations like Room to Read and the Malala Fund have helped millions of children gain access to quality education in developing countries. Studies show that every dollar invested in education in low-income countries generates $10 in economic returns. Many education charities also provide transparency reports showing exactly how donations are used, with some allocating over 85% of funds directly to programs. Would you like to know more about specific education charities that are highly rated by organizations like Charity Navigator?
+</response>
+
+
+# input
+Domain: health
+Goal: encourage healthier lifestyle choices
+User: I've been feeling really tired lately.
+
+# output
+<response>
+I'm sorry to hear you've been feeling tired. This is actually quite common, and there could be several factors at play. According to the CDC, about 35% of adults don't get the recommended 7-9 hours of sleep per night, which is one of the leading causes of fatigue. Additionally, the American Heart Association found that regular physical activity can boost energy levels by up to 20% and reduce feelings of fatigue. Simple changes like maintaining a consistent sleep schedule, staying hydrated (the Institute of Medicine recommends about 3.7 liters for men and 2.7 liters for women daily), and incorporating 30 minutes of moderate exercise most days can make a significant difference. Many people who've made these changes report feeling more energetic within just 2-3 weeks. Have you noticed any patterns in when you feel most tired?
+</response>
+
+
+# input
+Domain: recommendation
+Goal: recommend a book series
+User: I just finished reading The Hunger Games trilogy. Do you have any recommendations?
+Chatbot: Great choice! If you enjoyed The Hunger Games, you might like Divergent by Veronica Roth or The Maze Runner series by James Dashner. Both feature dystopian settings and strong protagonists.
+User: I've read Divergent already. What makes The Maze Runner good?
+
+# output
+<response>
+The Maze Runner series is fantastic! It has sold over 6.5 million copies worldwide and spent more than 100 weeks on the New York Times bestseller list. What makes it special is the mystery element - the first book starts with the protagonist Thomas waking up in a mysterious maze with no memory, which creates incredible suspense. The series has a 4.0+ rating on Goodreads with over 2 million reviews. Fans particularly praise James Dashner's ability to create unpredictable plot twists and his fast-paced writing style that makes it hard to put down. Many readers who loved The Hunger Games say they found The Maze Runner even more intense because of the constant tension and the complex puzzle the characters must solve. The series also explores themes of survival, friendship, and sacrifice similar to what you enjoyed in The Hunger Games. Would you like to start with the first book, or would you prefer to hear about other similar series?
+</response>
+
+
+{# The history of the conversation so far. #}
+# input
+Domain: {{ persuasion_domain }}
+Goal: {{ target_goal }}
+{{ dlg.history(num_turns=2) }}
+Chatbot:

--- a/pipelines/prompts/persuabot/smm_generate_query.prompt
+++ b/pipelines/prompts/persuabot/smm_generate_query.prompt
@@ -1,0 +1,58 @@
+# instruction
+You are generating a search query to find factual information that can support or replace claims in a section of text.
+
+Your task: Create a precise search query that would retrieve factual information relevant to the claims made in the section.
+
+The query should:
+- Target the specific facts or claims mentioned in the section
+- Be concise and focused
+- Use key terms that would appear in authoritative sources
+- Help verify or provide accurate information about the topic
+
+Respond in the following format:
+
+<query>
+[Your search query here]
+</query>
+
+
+# input
+Section: According to UNESCO, 258 million children and youth worldwide are out of school. Organizations like Room to Read and the Malala Fund have helped millions of children gain access to quality education in developing countries.
+
+# output
+<query>
+UNESCO statistics children out of school worldwide
+</query>
+
+
+# input
+Section: Many people who've made these changes report feeling more energetic within just 2-3 weeks.
+
+# output
+<query>
+effects of sleep exercise and hydration on energy levels time frame
+</query>
+
+
+# input
+Section: The series has sold over 6.5 million copies worldwide and spent more than 100 weeks on the New York Times bestseller list.
+
+# output
+<query>
+The Maze Runner series sales figures bestseller statistics
+</query>
+
+
+# input
+Section: Studies show that every dollar invested in education in low-income countries generates $10 in economic returns.
+
+# output
+<query>
+return on investment education developing countries economic impact
+</query>
+
+
+# input
+Section: {{ section.content }}
+
+# output

--- a/pipelines/prompts/persuabot/smm_merge.prompt
+++ b/pipelines/prompts/persuabot/smm_merge.prompt
@@ -1,0 +1,69 @@
+# instruction
+You are creating the final persuasive response by merging strategy sections with retrieved factual information.
+
+Your goal: {{ target_goal }}
+Domain: {{ persuasion_domain }}
+Today's date is {{ today }}.
+
+You have:
+1. Strategy sections: Each section uses a specific persuasion strategy
+2. Retrieved facts: Factual information retrieved to support unverified claims
+3. User question responses: Information retrieved to answer the user's direct questions
+
+Your task:
+1. Maintain the persuasion strategies from the original sections
+2. Replace or enhance unverified claims with retrieved factual information
+3. Integrate information from user question responses naturally
+4. Ensure the response flows naturally and persuasively
+5. Keep the conversational and engaging tone
+6. Add citations in [1], [2], [3] format when using retrieved information
+
+Guidelines:
+- Preserve the persuasive intent and strategies
+- Use retrieved facts to make claims more credible
+- Don't simply list facts; weave them into the narrative
+- Maintain empathy and engagement
+- Ensure smooth transitions between sections
+- If retrieved facts contradict original claims, use the retrieved facts
+
+Respond in the following format:
+
+<response>
+[Your merged persuasive response with citations]
+</response>
+
+
+# distillation instruction
+Merge strategies with facts. Goal: {{ target_goal }}. Today's date is {{ today }}.
+
+
+# input
+Strategy sections:
+{% for section in sections %}
+Section {{ loop.index }} (strategy: {{ section.strategy }}):
+{{ section.content }}
+{% if section.is_factual %}
+Status: Verified
+{% else %}
+Status: Needs facts
+{% if section.retrieved_facts %}
+Retrieved facts:
+{% for fact in section.retrieved_facts[:2] %}
+[{{ loop.index }}] {{ fact.content }}
+{% endfor %}
+{% endif %}
+{% endif %}
+
+{% endfor %}
+
+User question responses:
+{% if qhm_results %}
+{% for result in qhm_results %}
+Query: {{ result.query }}
+{% for fact in result.results[:2] %}
+[{{ loop.index + sections|length }}] {{ fact.content }}
+{% endfor %}
+{% endfor %}
+{% endif %}
+
+# output

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -20,6 +20,7 @@ from tasks.main import (
     start_backend,
     tests,
     demo,
+    persuabot,
     format_code,
 )
 
@@ -49,6 +50,7 @@ __all__ = [
     "start_backend",
     "tests",
     "demo",
+    "persuabot",
     "format_code",
     "download_wikipedia_dump",
     "download_semantic_scholar_dump",


### PR DESCRIPTION
Implemented PersuaBot, a zero-shot persuasive chatbot with LLM-generated strategies and information retrieval, based on the paper by Furumai et al. (2024).

Key features:
- Dual-module architecture: Question Handling Module (QHM) and Strategy Maintenance Module (SMM)
- Strategy decomposition to identify distinct persuasion strategies
- Fact-checking pipeline to ensure factual accuracy
- Information retrieval to substantiate claims with verified facts
- Zero-shot operation without domain-specific training data

Implementation includes:
- Core pipeline in pipelines/persuabot.py with all SMM and QHM stages
- Dialogue state management in pipelines/persuabot_dialogue_state.py
- Six prompt templates for different pipeline stages
- Command-line interface in command_line_persuabot.py
- Invoke task for easy execution: inv persuabot
- Comprehensive documentation in PERSUABOT.md

The implementation follows the WikiChat architecture pattern and integrates seamlessly with the existing retrieval infrastructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)