### PR TITLE
feat: Add Retrieval Quality Evaluation Framework and Hallucination Detection Module

### DIFF
--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -1,0 +1,180 @@
+# Retrieval Quality Evaluation Framework
+
+A comprehensive evaluation framework for assessing retrieval quality in WikiChat.
+
+## Overview
+
+This module provides tools for:
+- Computing standard IR metrics (Precision@K, Recall@K, MRR, NDCG)
+- Semantic similarity and diversity scoring
+- Building ground truth datasets with LLM-assisted labeling
+- Batch evaluation and comparison reporting
+
+## Installation
+
+The evaluation module uses dependencies already included in WikiChat:
+- `numpy` for numerical computations
+- `pydantic` for data validation
+
+Optional dependencies for LLM-assisted labeling:
+- `chainlite` (included in WikiChat)
+
+## Usage
+
+### Computing Retrieval Metrics
+
+```python
+from evaluation.retrieval_metrics import (
+    RetrievalMetrics,
+    precision_at_k,
+    recall_at_k,
+    mean_reciprocal_rank,
+    ndcg_at_k,
+)
+
+# Simple metric computation
+retrieved_ids = ["doc1", "doc2", "doc3", "doc4", "doc5"]
+relevant_ids = ["doc1", "doc3", "doc7"]
+
+p_at_5 = precision_at_k(retrieved_ids, relevant_ids, k=5)
+r_at_5 = recall_at_k(retrieved_ids, relevant_ids, k=5)
+mrr = mean_reciprocal_rank(retrieved_ids, relevant_ids)
+
+# Comprehensive metrics with RetrievalMetrics class
+metrics = RetrievalMetrics(k_values=[1, 3, 5, 10])
+query_metrics = metrics.compute_all_metrics(
+    query="What is Python?",
+    retrieved_ids=retrieved_ids,
+    relevant_ids=relevant_ids,
+)
+print(f"Precision@5: {query_metrics.precision_at_k[5]}")
+print(f"MRR: {query_metrics.mrr}")
+```
+
+### Building Ground Truth Datasets
+
+```python
+from evaluation.ground_truth_builder import GroundTruthBuilder, RelevanceLabel
+
+# Create a new dataset
+builder = GroundTruthBuilder(
+    dataset_name="wikipedia_retrieval_eval",
+    description="Evaluation dataset for Wikipedia retrieval",
+)
+
+# Add manual annotations
+builder.add_annotation(
+    query="What is Python programming?",
+    document_id="doc_python_intro",
+    document_title="Python (programming language)",
+    document_content="Python is a high-level programming language...",
+    label=RelevanceLabel.HIGHLY_RELEVANT,
+)
+
+# Save the dataset
+builder.save("ground_truth/wikipedia_eval.json")
+
+# Load an existing dataset
+loaded_builder = GroundTruthBuilder.load("ground_truth/wikipedia_eval.json")
+```
+
+### LLM-Assisted Labeling
+
+```python
+import asyncio
+from evaluation.ground_truth_builder import GroundTruthBuilder
+
+builder = GroundTruthBuilder(
+    dataset_name="auto_labeled",
+    llm_engine="gpt-4o",  # or any configured engine
+)
+
+# Label a single document
+annotation = asyncio.run(builder.label_with_llm(
+    query="What is machine learning?",
+    document_id="doc1",
+    document_title="Machine Learning Overview",
+    document_content="Machine learning is a subset of artificial intelligence...",
+))
+```
+
+### Running Batch Evaluations
+
+```python
+from evaluation.eval_runner import (
+    EvaluationRunner,
+    EvaluationConfig,
+    RetrievalResult,
+)
+from evaluation.ground_truth_builder import GroundTruthBuilder
+
+# Load ground truth
+builder = GroundTruthBuilder.load("ground_truth/wikipedia_eval.json")
+
+# Configure evaluation
+config = EvaluationConfig(
+    name="baseline_evaluation",
+    k_values=[1, 3, 5, 10],
+    output_dir="evaluation_results",
+)
+
+# Create runner
+runner = EvaluationRunner(
+    ground_truth=builder.dataset,
+    config=config,
+)
+
+# Prepare results (from your retrieval system)
+results = [
+    RetrievalResult(
+        query="What is Python?",
+        retrieved_ids=["doc1", "doc2", "doc3"],
+    ),
+]
+
+# Run evaluation
+report = runner.evaluate_batch(results)
+print(report.to_summary_string())
+
+# Save report
+runner.save_report(report)
+```
+
+### Comparing Configurations
+
+```python
+from evaluation.eval_runner import compare_evaluations, generate_comparison_report
+
+reports = [baseline_report, improved_report]  # EvaluationReport objects
+comparison = compare_evaluations(reports)
+generate_comparison_report(reports, "comparison_results/report.json")
+```
+
+## Metrics Reference
+
+| Metric | Description | Range |
+|--------|-------------|-------|
+| Precision@K | Fraction of top-K results that are relevant | [0, 1] |
+| Recall@K | Fraction of relevant documents in top-K | [0, 1] |
+| MRR | Reciprocal rank of first relevant result | [0, 1] |
+| NDCG@K | Normalized DCG accounting for rank positions | [0, 1] |
+| Semantic Similarity | Cosine similarity between query and results | [-1, 1] |
+| Diversity | Average pairwise dissimilarity of results | [0, 1] |
+
+## File Structure
+
+```
+evaluation/
+    __init__.py           # Module exports
+    retrieval_metrics.py  # Core metric implementations
+    ground_truth_builder.py  # Dataset building tools
+    eval_runner.py        # Batch evaluation runner
+    README.md             # This file
+```
+
+## Testing
+
+```bash
+pytest tests/test_evaluation.py -v
+```
+

--- a/evaluation/__init__.py
+++ b/evaluation/__init__.py
@@ -1,0 +1,38 @@
+"""
+Retrieval Quality Evaluation Framework for WikiChat.
+
+This module provides tools for evaluating retrieval quality including:
+- Precision@K, Recall@K, MRR, NDCG metrics
+- Semantic similarity scoring
+- Diversity metrics
+- Ground truth dataset building
+- Batch evaluation and comparison reporting
+"""
+
+from evaluation.retrieval_metrics import (
+    RetrievalMetrics,
+    precision_at_k,
+    recall_at_k,
+    mean_reciprocal_rank,
+    ndcg_at_k,
+    semantic_similarity,
+    diversity_score,
+)
+from evaluation.ground_truth_builder import GroundTruthBuilder, RelevanceLabel
+from evaluation.eval_runner import EvaluationRunner, EvaluationConfig, EvaluationReport
+
+__all__ = [
+    "RetrievalMetrics",
+    "precision_at_k",
+    "recall_at_k",
+    "mean_reciprocal_rank",
+    "ndcg_at_k",
+    "semantic_similarity",
+    "diversity_score",
+    "GroundTruthBuilder",
+    "RelevanceLabel",
+    "EvaluationRunner",
+    "EvaluationConfig",
+    "EvaluationReport",
+]
+

--- a/evaluation/eval_runner.py
+++ b/evaluation/eval_runner.py
@@ -1,0 +1,349 @@
+"""
+Batch evaluation runner for retrieval quality assessment.
+
+Provides tools for running evaluations across multiple queries and
+generating comparison reports.
+"""
+
+import asyncio
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, Optional
+
+from pydantic import BaseModel, Field
+
+from evaluation.ground_truth_builder import GroundTruthBuilder, GroundTruthDataset
+from evaluation.retrieval_metrics import (
+    QueryMetrics,
+    RetrievalMetrics,
+    aggregate_metrics,
+)
+
+
+class EvaluationConfig(BaseModel):
+    """Configuration for an evaluation run."""
+
+    name: str = Field(..., description="Evaluation run name")
+    k_values: list[int] = Field(
+        default_factory=lambda: [1, 3, 5, 10],
+        description="K values for metrics computation",
+    )
+    compute_semantic_similarity: bool = Field(
+        True, description="Whether to compute semantic similarity"
+    )
+    compute_diversity: bool = Field(True, description="Whether to compute diversity")
+    output_dir: str = Field("evaluation_results", description="Output directory")
+
+
+class RetrievalResult(BaseModel):
+    """Result from a retrieval system for a single query."""
+
+    query: str = Field(..., description="The query string")
+    retrieved_ids: list[str] = Field(..., description="Retrieved document IDs")
+    retrieved_titles: list[str] = Field(
+        default_factory=list, description="Retrieved document titles"
+    )
+    scores: list[float] = Field(
+        default_factory=list, description="Retrieval scores"
+    )
+    embeddings: Optional[list[list[float]]] = Field(
+        None, description="Document embeddings if available"
+    )
+    query_embedding: Optional[list[float]] = Field(
+        None, description="Query embedding if available"
+    )
+
+
+class EvaluationReport(BaseModel):
+    """Complete evaluation report."""
+
+    config: EvaluationConfig = Field(..., description="Evaluation configuration")
+    timestamp: datetime = Field(
+        default_factory=datetime.now, description="Evaluation timestamp"
+    )
+    ground_truth_name: str = Field(..., description="Ground truth dataset name")
+    num_queries: int = Field(..., description="Number of queries evaluated")
+    per_query_metrics: list[QueryMetrics] = Field(
+        default_factory=list, description="Metrics for each query"
+    )
+    aggregated_metrics: dict = Field(
+        default_factory=dict, description="Aggregated metrics across queries"
+    )
+    metadata: dict = Field(default_factory=dict, description="Additional metadata")
+
+    def to_summary_string(self) -> str:
+        """Generate a human-readable summary of the evaluation."""
+        lines = [
+            f"Evaluation Report: {self.config.name}",
+            f"Timestamp: {self.timestamp.isoformat()}",
+            f"Ground Truth: {self.ground_truth_name}",
+            f"Queries Evaluated: {self.num_queries}",
+            "",
+            "Aggregated Metrics:",
+            "-" * 40,
+        ]
+
+        for metric_name, values in sorted(self.aggregated_metrics.items()):
+            if isinstance(values, dict):
+                mean = values.get("mean", 0)
+                std = values.get("std", 0)
+                lines.append(f"  {metric_name}: {mean:.4f} (+/- {std:.4f})")
+            else:
+                lines.append(f"  {metric_name}: {values:.4f}")
+
+        return "\n".join(lines)
+
+
+@dataclass
+class EvaluationRunner:
+    """
+    Runner for batch retrieval evaluation.
+
+    Evaluates retrieval results against ground truth datasets and
+    generates comprehensive reports.
+    """
+
+    ground_truth: GroundTruthDataset
+    config: EvaluationConfig
+    metrics_calculator: RetrievalMetrics = field(init=False)
+
+    def __post_init__(self):
+        self.metrics_calculator = RetrievalMetrics(k_values=self.config.k_values)
+
+    def evaluate_single(self, result: RetrievalResult) -> QueryMetrics:
+        """
+        Evaluate a single retrieval result.
+
+        Args:
+            result: Retrieval result for a query
+
+        Returns:
+            QueryMetrics for the result
+        """
+        relevant_ids = self.ground_truth.get_relevant_ids(result.query)
+        relevance_scores = self.ground_truth.get_relevance_scores(result.query)
+
+        return self.metrics_calculator.compute_all_metrics(
+            query=result.query,
+            retrieved_ids=result.retrieved_ids,
+            relevant_ids=relevant_ids,
+            relevance_scores=relevance_scores if relevance_scores else None,
+            query_embedding=(
+                result.query_embedding
+                if self.config.compute_semantic_similarity
+                else None
+            ),
+            result_embeddings=(
+                result.embeddings if self.config.compute_diversity else None
+            ),
+        )
+
+    def evaluate_batch(self, results: list[RetrievalResult]) -> EvaluationReport:
+        """
+        Evaluate a batch of retrieval results.
+
+        Args:
+            results: List of retrieval results
+
+        Returns:
+            Complete evaluation report
+        """
+        per_query_metrics = []
+
+        for result in results:
+            if result.query in self.ground_truth.get_queries():
+                metrics = self.evaluate_single(result)
+                per_query_metrics.append(metrics)
+
+        aggregated = aggregate_metrics(per_query_metrics)
+
+        return EvaluationReport(
+            config=self.config,
+            ground_truth_name=self.ground_truth.name,
+            num_queries=len(per_query_metrics),
+            per_query_metrics=per_query_metrics,
+            aggregated_metrics=aggregated,
+        )
+
+    def save_report(self, report: EvaluationReport) -> str:
+        """
+        Save evaluation report to file.
+
+        Args:
+            report: Evaluation report to save
+
+        Returns:
+            Path to saved report
+        """
+        output_dir = Path(self.config.output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        timestamp = report.timestamp.strftime("%Y%m%d_%H%M%S")
+        filename = f"{self.config.name}_{timestamp}.json"
+        filepath = output_dir / filename
+
+        with open(filepath, "w", encoding="utf-8") as f:
+            json.dump(report.model_dump(mode="json"), f, indent=2, default=str)
+
+        summary_path = output_dir / f"{self.config.name}_{timestamp}_summary.txt"
+        with open(summary_path, "w", encoding="utf-8") as f:
+            f.write(report.to_summary_string())
+
+        return str(filepath)
+
+    @classmethod
+    def from_ground_truth_file(
+        cls, ground_truth_path: str, config: EvaluationConfig
+    ) -> "EvaluationRunner":
+        """
+        Create runner from a ground truth file.
+
+        Args:
+            ground_truth_path: Path to ground truth JSON file
+            config: Evaluation configuration
+
+        Returns:
+            Configured EvaluationRunner
+        """
+        builder = GroundTruthBuilder.load(ground_truth_path)
+        return cls(ground_truth=builder.dataset, config=config)
+
+
+def compare_evaluations(reports: list[EvaluationReport]) -> dict:
+    """
+    Compare multiple evaluation reports.
+
+    Args:
+        reports: List of evaluation reports to compare
+
+    Returns:
+        Comparison dictionary with metrics for each report
+    """
+    if not reports:
+        return {}
+
+    comparison = {
+        "reports": [r.config.name for r in reports],
+        "metrics_comparison": {},
+    }
+
+    all_metrics = set()
+    for report in reports:
+        all_metrics.update(report.aggregated_metrics.keys())
+
+    for metric in sorted(all_metrics):
+        comparison["metrics_comparison"][metric] = {}
+        for report in reports:
+            if metric in report.aggregated_metrics:
+                values = report.aggregated_metrics[metric]
+                if isinstance(values, dict):
+                    comparison["metrics_comparison"][metric][report.config.name] = {
+                        "mean": values.get("mean", 0),
+                        "std": values.get("std", 0),
+                    }
+                else:
+                    comparison["metrics_comparison"][metric][report.config.name] = {
+                        "mean": values,
+                        "std": 0,
+                    }
+
+    best_per_metric = {}
+    for metric, results in comparison["metrics_comparison"].items():
+        best_name = None
+        best_value = -float("inf")
+        for name, values in results.items():
+            if values["mean"] > best_value:
+                best_value = values["mean"]
+                best_name = name
+        best_per_metric[metric] = best_name
+
+    comparison["best_per_metric"] = best_per_metric
+
+    return comparison
+
+
+def generate_comparison_report(
+    reports: list[EvaluationReport], output_path: str
+) -> None:
+    """
+    Generate a comparison report for multiple evaluations.
+
+    Args:
+        reports: List of evaluation reports
+        output_path: Path to save the comparison report
+    """
+    comparison = compare_evaluations(reports)
+
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(comparison, f, indent=2)
+
+    summary_lines = [
+        "Evaluation Comparison Report",
+        "=" * 50,
+        "",
+        f"Comparing: {', '.join(comparison['reports'])}",
+        "",
+        "Metrics Comparison:",
+        "-" * 50,
+    ]
+
+    for metric, results in sorted(comparison["metrics_comparison"].items()):
+        summary_lines.append(f"\n{metric}:")
+        for name, values in results.items():
+            is_best = comparison["best_per_metric"].get(metric) == name
+            marker = " *" if is_best else ""
+            summary_lines.append(
+                f"  {name}: {values['mean']:.4f} (+/- {values['std']:.4f}){marker}"
+            )
+
+    summary_lines.extend(
+        [
+            "",
+            "-" * 50,
+            "* indicates best performing configuration",
+        ]
+    )
+
+    summary_path = path.with_suffix(".txt")
+    with open(summary_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(summary_lines))
+
+
+async def run_retrieval_evaluation(
+    retriever_fn: Callable[[str], RetrievalResult],
+    ground_truth_path: str,
+    config: EvaluationConfig,
+    queries: Optional[list[str]] = None,
+) -> EvaluationReport:
+    """
+    Run a complete retrieval evaluation.
+
+    Args:
+        retriever_fn: Function that takes a query and returns RetrievalResult
+        ground_truth_path: Path to ground truth dataset
+        config: Evaluation configuration
+        queries: Optional list of queries to evaluate (uses all if not provided)
+
+    Returns:
+        Complete evaluation report
+    """
+    runner = EvaluationRunner.from_ground_truth_file(ground_truth_path, config)
+
+    if queries is None:
+        queries = runner.ground_truth.get_queries()
+
+    results = []
+    for query in queries:
+        result = retriever_fn(query)
+        results.append(result)
+
+    report = runner.evaluate_batch(results)
+    runner.save_report(report)
+
+    return report
+

--- a/evaluation/ground_truth_builder.py
+++ b/evaluation/ground_truth_builder.py
@@ -1,0 +1,383 @@
+"""
+Ground truth dataset builder for retrieval evaluation.
+
+Provides tools for building and managing ground truth relevance labels,
+including LLM-assisted relevance labeling.
+"""
+
+import asyncio
+import json
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class RelevanceLabel(str, Enum):
+    """Relevance labels for ground truth annotation."""
+
+    HIGHLY_RELEVANT = "highly_relevant"
+    RELEVANT = "relevant"
+    PARTIALLY_RELEVANT = "partially_relevant"
+    NOT_RELEVANT = "not_relevant"
+
+    @property
+    def score(self) -> float:
+        """Convert label to numeric score for graded metrics."""
+        scores = {
+            RelevanceLabel.HIGHLY_RELEVANT: 3.0,
+            RelevanceLabel.RELEVANT: 2.0,
+            RelevanceLabel.PARTIALLY_RELEVANT: 1.0,
+            RelevanceLabel.NOT_RELEVANT: 0.0,
+        }
+        return scores[self]
+
+
+class RelevanceAnnotation(BaseModel):
+    """A single relevance annotation for a query-document pair."""
+
+    query: str = Field(..., description="The query string")
+    document_id: str = Field(..., description="The document identifier")
+    document_title: str = Field(..., description="Document title for reference")
+    document_content: str = Field(..., description="Document content snippet")
+    label: RelevanceLabel = Field(..., description="Relevance label")
+    confidence: float = Field(
+        1.0, ge=0.0, le=1.0, description="Annotation confidence score"
+    )
+    annotator: str = Field("human", description="Annotator identifier")
+    timestamp: datetime = Field(
+        default_factory=datetime.now, description="Annotation timestamp"
+    )
+    notes: Optional[str] = Field(None, description="Optional annotation notes")
+
+
+class GroundTruthDataset(BaseModel):
+    """A collection of relevance annotations for evaluation."""
+
+    name: str = Field(..., description="Dataset name")
+    description: str = Field("", description="Dataset description")
+    created_at: datetime = Field(
+        default_factory=datetime.now, description="Creation timestamp"
+    )
+    annotations: list[RelevanceAnnotation] = Field(
+        default_factory=list, description="List of annotations"
+    )
+    metadata: dict = Field(default_factory=dict, description="Additional metadata")
+
+    def get_relevant_ids(self, query: str) -> list[str]:
+        """Get list of relevant document IDs for a query."""
+        return [
+            ann.document_id
+            for ann in self.annotations
+            if ann.query == query and ann.label != RelevanceLabel.NOT_RELEVANT
+        ]
+
+    def get_relevance_scores(self, query: str) -> dict[str, float]:
+        """Get graded relevance scores for a query."""
+        return {
+            ann.document_id: ann.label.score
+            for ann in self.annotations
+            if ann.query == query
+        }
+
+    def get_queries(self) -> list[str]:
+        """Get list of unique queries in the dataset."""
+        return list(set(ann.query for ann in self.annotations))
+
+
+class GroundTruthBuilder:
+    """
+    Builder for creating ground truth relevance datasets.
+
+    Supports both manual annotation and LLM-assisted labeling.
+    """
+
+    def __init__(
+        self,
+        dataset_name: str,
+        description: str = "",
+        llm_engine: Optional[str] = None,
+    ):
+        """
+        Initialize the ground truth builder.
+
+        Args:
+            dataset_name: Name for the dataset
+            description: Dataset description
+            llm_engine: Optional LLM engine for assisted labeling
+        """
+        self.dataset = GroundTruthDataset(
+            name=dataset_name,
+            description=description,
+        )
+        self.llm_engine = llm_engine
+
+    def add_annotation(
+        self,
+        query: str,
+        document_id: str,
+        document_title: str,
+        document_content: str,
+        label: RelevanceLabel,
+        confidence: float = 1.0,
+        annotator: str = "human",
+        notes: Optional[str] = None,
+    ) -> None:
+        """
+        Add a manual relevance annotation.
+
+        Args:
+            query: The query string
+            document_id: Document identifier
+            document_title: Document title
+            document_content: Document content snippet
+            label: Relevance label
+            confidence: Annotation confidence
+            annotator: Annotator identifier
+            notes: Optional notes
+        """
+        annotation = RelevanceAnnotation(
+            query=query,
+            document_id=document_id,
+            document_title=document_title,
+            document_content=document_content,
+            label=label,
+            confidence=confidence,
+            annotator=annotator,
+            notes=notes,
+        )
+        self.dataset.annotations.append(annotation)
+
+    async def label_with_llm(
+        self,
+        query: str,
+        document_id: str,
+        document_title: str,
+        document_content: str,
+    ) -> RelevanceAnnotation:
+        """
+        Use LLM to generate a relevance label.
+
+        Args:
+            query: The query string
+            document_id: Document identifier
+            document_title: Document title
+            document_content: Document content
+
+        Returns:
+            RelevanceAnnotation with LLM-generated label
+        """
+        if self.llm_engine is None:
+            raise ValueError("LLM engine not configured for assisted labeling")
+
+        try:
+            from chainlite import llm_generation_chain
+        except ImportError:
+            raise ImportError(
+                "chainlite is required for LLM-assisted labeling. "
+                "Install it with: pip install chainlite"
+            )
+
+        prompt = f"""Evaluate the relevance of the following document to the query.
+
+Query: {query}
+
+Document Title: {document_title}
+Document Content: {document_content}
+
+Rate the relevance using one of these labels:
+- highly_relevant: The document directly and completely answers the query
+- relevant: The document provides useful information related to the query
+- partially_relevant: The document has some connection to the query but is not very helpful
+- not_relevant: The document is not related to the query
+
+Respond with ONLY the label (e.g., "highly_relevant")."""
+
+        chain = llm_generation_chain(
+            template_file=None,
+            engine=self.llm_engine,
+            max_tokens=20,
+        )
+
+        response = await chain.ainvoke({"text": prompt})
+        response = response.strip().lower().replace(" ", "_")
+
+        label_map = {
+            "highly_relevant": RelevanceLabel.HIGHLY_RELEVANT,
+            "relevant": RelevanceLabel.RELEVANT,
+            "partially_relevant": RelevanceLabel.PARTIALLY_RELEVANT,
+            "not_relevant": RelevanceLabel.NOT_RELEVANT,
+        }
+
+        label = label_map.get(response, RelevanceLabel.NOT_RELEVANT)
+
+        annotation = RelevanceAnnotation(
+            query=query,
+            document_id=document_id,
+            document_title=document_title,
+            document_content=document_content,
+            label=label,
+            confidence=0.8,
+            annotator=f"llm:{self.llm_engine}",
+        )
+
+        self.dataset.annotations.append(annotation)
+        return annotation
+
+    async def batch_label_with_llm(
+        self,
+        items: list[dict],
+    ) -> list[RelevanceAnnotation]:
+        """
+        Batch label multiple query-document pairs with LLM.
+
+        Args:
+            items: List of dicts with keys: query, document_id, document_title, document_content
+
+        Returns:
+            List of RelevanceAnnotations
+        """
+        tasks = [
+            self.label_with_llm(
+                query=item["query"],
+                document_id=item["document_id"],
+                document_title=item["document_title"],
+                document_content=item["document_content"],
+            )
+            for item in items
+        ]
+        return await asyncio.gather(*tasks)
+
+    def save(self, file_path: str) -> None:
+        """
+        Save the dataset to a JSON file.
+
+        Args:
+            file_path: Path to save the dataset
+        """
+        path = Path(file_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(self.dataset.model_dump(mode="json"), f, indent=2, default=str)
+
+    @classmethod
+    def load(cls, file_path: str) -> "GroundTruthBuilder":
+        """
+        Load a dataset from a JSON file.
+
+        Args:
+            file_path: Path to the dataset file
+
+        Returns:
+            GroundTruthBuilder with loaded dataset
+        """
+        with open(file_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        dataset = GroundTruthDataset.model_validate(data)
+        builder = cls(dataset_name=dataset.name, description=dataset.description)
+        builder.dataset = dataset
+        return builder
+
+    def export_for_sharing(self, file_path: str, include_content: bool = True) -> None:
+        """
+        Export dataset in a format suitable for sharing.
+
+        Args:
+            file_path: Path to save the export
+            include_content: Whether to include document content
+        """
+        export_data = {
+            "name": self.dataset.name,
+            "description": self.dataset.description,
+            "version": "1.0",
+            "queries": {},
+        }
+
+        for ann in self.dataset.annotations:
+            if ann.query not in export_data["queries"]:
+                export_data["queries"][ann.query] = []
+
+            doc_data = {
+                "document_id": ann.document_id,
+                "document_title": ann.document_title,
+                "label": ann.label.value,
+                "score": ann.label.score,
+            }
+
+            if include_content:
+                doc_data["document_content"] = ann.document_content
+
+            export_data["queries"][ann.query].append(doc_data)
+
+        path = Path(file_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(export_data, f, indent=2, ensure_ascii=False)
+
+    @classmethod
+    def import_from_sharing_format(cls, file_path: str) -> "GroundTruthBuilder":
+        """
+        Import dataset from sharing format.
+
+        Args:
+            file_path: Path to the import file
+
+        Returns:
+            GroundTruthBuilder with imported dataset
+        """
+        with open(file_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        builder = cls(
+            dataset_name=data.get("name", "imported_dataset"),
+            description=data.get("description", ""),
+        )
+
+        label_map = {
+            "highly_relevant": RelevanceLabel.HIGHLY_RELEVANT,
+            "relevant": RelevanceLabel.RELEVANT,
+            "partially_relevant": RelevanceLabel.PARTIALLY_RELEVANT,
+            "not_relevant": RelevanceLabel.NOT_RELEVANT,
+        }
+
+        for query, documents in data.get("queries", {}).items():
+            for doc in documents:
+                builder.add_annotation(
+                    query=query,
+                    document_id=doc["document_id"],
+                    document_title=doc["document_title"],
+                    document_content=doc.get("document_content", ""),
+                    label=label_map.get(doc["label"], RelevanceLabel.NOT_RELEVANT),
+                )
+
+        return builder
+
+    def get_statistics(self) -> dict:
+        """
+        Get statistics about the dataset.
+
+        Returns:
+            Dictionary with dataset statistics
+        """
+        queries = self.dataset.get_queries()
+        label_counts = {label: 0 for label in RelevanceLabel}
+
+        for ann in self.dataset.annotations:
+            label_counts[ann.label] += 1
+
+        return {
+            "total_annotations": len(self.dataset.annotations),
+            "unique_queries": len(queries),
+            "label_distribution": {
+                label.value: count for label, count in label_counts.items()
+            },
+            "avg_annotations_per_query": (
+                len(self.dataset.annotations) / len(queries) if queries else 0
+            ),
+        }
+

--- a/evaluation/retrieval_metrics.py
+++ b/evaluation/retrieval_metrics.py
@@ -1,0 +1,411 @@
+"""
+Retrieval quality metrics for evaluating search results.
+
+Provides standard IR metrics including Precision@K, Recall@K, MRR, NDCG,
+as well as semantic similarity and diversity metrics.
+"""
+
+import math
+from dataclasses import dataclass, field
+from typing import Optional
+
+import numpy as np
+from pydantic import BaseModel, Field
+
+
+class MetricResult(BaseModel):
+    """Result of a single metric computation."""
+
+    metric_name: str = Field(..., description="Name of the metric")
+    value: float = Field(..., description="Computed metric value")
+    k: Optional[int] = Field(None, description="K value if applicable")
+    details: Optional[dict] = Field(None, description="Additional metric details")
+
+
+class QueryMetrics(BaseModel):
+    """Aggregated metrics for a single query."""
+
+    query: str = Field(..., description="The query string")
+    precision_at_k: dict[int, float] = Field(
+        default_factory=dict, description="Precision@K for various K values"
+    )
+    recall_at_k: dict[int, float] = Field(
+        default_factory=dict, description="Recall@K for various K values"
+    )
+    mrr: float = Field(0.0, description="Mean Reciprocal Rank")
+    ndcg_at_k: dict[int, float] = Field(
+        default_factory=dict, description="NDCG@K for various K values"
+    )
+    semantic_similarity: float = Field(
+        0.0, description="Average semantic similarity of results"
+    )
+    diversity: float = Field(0.0, description="Diversity score of results")
+
+
+@dataclass
+class RetrievalMetrics:
+    """
+    Comprehensive retrieval metrics calculator.
+
+    Computes standard IR metrics for evaluating retrieval quality:
+    - Precision@K: Fraction of retrieved documents that are relevant
+    - Recall@K: Fraction of relevant documents that are retrieved
+    - MRR: Mean Reciprocal Rank of first relevant result
+    - NDCG@K: Normalized Discounted Cumulative Gain
+    - Semantic Similarity: Cosine similarity between query and results
+    - Diversity: Pairwise dissimilarity among retrieved results
+    """
+
+    k_values: list[int] = field(default_factory=lambda: [1, 3, 5, 10])
+
+    def compute_all_metrics(
+        self,
+        query: str,
+        retrieved_ids: list[str],
+        relevant_ids: list[str],
+        relevance_scores: Optional[dict[str, float]] = None,
+        query_embedding: Optional[list[float]] = None,
+        result_embeddings: Optional[list[list[float]]] = None,
+    ) -> QueryMetrics:
+        """
+        Compute all retrieval metrics for a single query.
+
+        Args:
+            query: The query string
+            retrieved_ids: List of retrieved document IDs in rank order
+            relevant_ids: List of relevant document IDs (ground truth)
+            relevance_scores: Optional graded relevance scores per document
+            query_embedding: Optional query embedding for semantic similarity
+            result_embeddings: Optional result embeddings for similarity/diversity
+
+        Returns:
+            QueryMetrics with all computed metrics
+        """
+        metrics = QueryMetrics(query=query)
+
+        for k in self.k_values:
+            if k <= len(retrieved_ids):
+                metrics.precision_at_k[k] = precision_at_k(
+                    retrieved_ids, relevant_ids, k
+                )
+                metrics.recall_at_k[k] = recall_at_k(retrieved_ids, relevant_ids, k)
+                metrics.ndcg_at_k[k] = ndcg_at_k(
+                    retrieved_ids, relevant_ids, k, relevance_scores
+                )
+
+        metrics.mrr = mean_reciprocal_rank(retrieved_ids, relevant_ids)
+
+        if query_embedding is not None and result_embeddings:
+            metrics.semantic_similarity = semantic_similarity(
+                query_embedding, result_embeddings
+            )
+
+        if result_embeddings and len(result_embeddings) > 1:
+            metrics.diversity = diversity_score(result_embeddings)
+
+        return metrics
+
+
+def precision_at_k(
+    retrieved_ids: list[str], relevant_ids: list[str], k: int
+) -> float:
+    """
+    Compute Precision@K.
+
+    Args:
+        retrieved_ids: List of retrieved document IDs in rank order
+        relevant_ids: List of relevant document IDs
+        k: Number of top results to consider
+
+    Returns:
+        Precision@K value between 0 and 1
+    """
+    if k <= 0:
+        return 0.0
+
+    retrieved_at_k = set(retrieved_ids[:k])
+    relevant_set = set(relevant_ids)
+    relevant_retrieved = retrieved_at_k.intersection(relevant_set)
+
+    return len(relevant_retrieved) / k
+
+
+def recall_at_k(retrieved_ids: list[str], relevant_ids: list[str], k: int) -> float:
+    """
+    Compute Recall@K.
+
+    Args:
+        retrieved_ids: List of retrieved document IDs in rank order
+        relevant_ids: List of relevant document IDs
+        k: Number of top results to consider
+
+    Returns:
+        Recall@K value between 0 and 1
+    """
+    if not relevant_ids or k <= 0:
+        return 0.0
+
+    retrieved_at_k = set(retrieved_ids[:k])
+    relevant_set = set(relevant_ids)
+    relevant_retrieved = retrieved_at_k.intersection(relevant_set)
+
+    return len(relevant_retrieved) / len(relevant_set)
+
+
+def mean_reciprocal_rank(retrieved_ids: list[str], relevant_ids: list[str]) -> float:
+    """
+    Compute Mean Reciprocal Rank (MRR).
+
+    Returns the reciprocal of the rank of the first relevant result.
+
+    Args:
+        retrieved_ids: List of retrieved document IDs in rank order
+        relevant_ids: List of relevant document IDs
+
+    Returns:
+        MRR value between 0 and 1
+    """
+    relevant_set = set(relevant_ids)
+
+    for rank, doc_id in enumerate(retrieved_ids, start=1):
+        if doc_id in relevant_set:
+            return 1.0 / rank
+
+    return 0.0
+
+
+def dcg_at_k(
+    retrieved_ids: list[str],
+    relevant_ids: list[str],
+    k: int,
+    relevance_scores: Optional[dict[str, float]] = None,
+) -> float:
+    """
+    Compute Discounted Cumulative Gain at K.
+
+    Args:
+        retrieved_ids: List of retrieved document IDs in rank order
+        relevant_ids: List of relevant document IDs
+        k: Number of top results to consider
+        relevance_scores: Optional graded relevance scores (default: binary)
+
+    Returns:
+        DCG@K value
+    """
+    if k <= 0:
+        return 0.0
+
+    relevant_set = set(relevant_ids)
+    dcg = 0.0
+
+    for rank, doc_id in enumerate(retrieved_ids[:k], start=1):
+        if doc_id in relevant_set:
+            if relevance_scores and doc_id in relevance_scores:
+                rel = relevance_scores[doc_id]
+            else:
+                rel = 1.0
+            dcg += (2**rel - 1) / math.log2(rank + 1)
+
+    return dcg
+
+
+def ideal_dcg_at_k(
+    relevant_ids: list[str],
+    k: int,
+    relevance_scores: Optional[dict[str, float]] = None,
+) -> float:
+    """
+    Compute Ideal DCG at K (best possible DCG).
+
+    Args:
+        relevant_ids: List of relevant document IDs
+        k: Number of top results to consider
+        relevance_scores: Optional graded relevance scores
+
+    Returns:
+        Ideal DCG@K value
+    """
+    if not relevant_ids or k <= 0:
+        return 0.0
+
+    if relevance_scores:
+        sorted_scores = sorted(
+            [relevance_scores.get(doc_id, 1.0) for doc_id in relevant_ids],
+            reverse=True,
+        )
+    else:
+        sorted_scores = [1.0] * len(relevant_ids)
+
+    idcg = 0.0
+    for rank, rel in enumerate(sorted_scores[:k], start=1):
+        idcg += (2**rel - 1) / math.log2(rank + 1)
+
+    return idcg
+
+
+def ndcg_at_k(
+    retrieved_ids: list[str],
+    relevant_ids: list[str],
+    k: int,
+    relevance_scores: Optional[dict[str, float]] = None,
+) -> float:
+    """
+    Compute Normalized Discounted Cumulative Gain at K.
+
+    Args:
+        retrieved_ids: List of retrieved document IDs in rank order
+        relevant_ids: List of relevant document IDs
+        k: Number of top results to consider
+        relevance_scores: Optional graded relevance scores
+
+    Returns:
+        NDCG@K value between 0 and 1
+    """
+    dcg = dcg_at_k(retrieved_ids, relevant_ids, k, relevance_scores)
+    idcg = ideal_dcg_at_k(relevant_ids, k, relevance_scores)
+
+    if idcg == 0:
+        return 0.0
+
+    return dcg / idcg
+
+
+def cosine_similarity(vec1: list[float], vec2: list[float]) -> float:
+    """
+    Compute cosine similarity between two vectors.
+
+    Args:
+        vec1: First vector
+        vec2: Second vector
+
+    Returns:
+        Cosine similarity value between -1 and 1
+    """
+    arr1 = np.array(vec1)
+    arr2 = np.array(vec2)
+
+    dot_product = np.dot(arr1, arr2)
+    norm1 = np.linalg.norm(arr1)
+    norm2 = np.linalg.norm(arr2)
+
+    if norm1 == 0 or norm2 == 0:
+        return 0.0
+
+    return float(dot_product / (norm1 * norm2))
+
+
+def semantic_similarity(
+    query_embedding: list[float], result_embeddings: list[list[float]]
+) -> float:
+    """
+    Compute average semantic similarity between query and results.
+
+    Args:
+        query_embedding: Query embedding vector
+        result_embeddings: List of result embedding vectors
+
+    Returns:
+        Average cosine similarity between query and all results
+    """
+    if not result_embeddings:
+        return 0.0
+
+    similarities = [
+        cosine_similarity(query_embedding, result_emb)
+        for result_emb in result_embeddings
+    ]
+
+    return float(np.mean(similarities))
+
+
+def diversity_score(result_embeddings: list[list[float]]) -> float:
+    """
+    Compute diversity score as average pairwise dissimilarity.
+
+    Higher scores indicate more diverse results.
+
+    Args:
+        result_embeddings: List of result embedding vectors
+
+    Returns:
+        Diversity score between 0 and 1
+    """
+    n = len(result_embeddings)
+    if n < 2:
+        return 0.0
+
+    total_dissimilarity = 0.0
+    pair_count = 0
+
+    for i in range(n):
+        for j in range(i + 1, n):
+            similarity = cosine_similarity(result_embeddings[i], result_embeddings[j])
+            total_dissimilarity += 1.0 - similarity
+            pair_count += 1
+
+    return total_dissimilarity / pair_count if pair_count > 0 else 0.0
+
+
+def aggregate_metrics(query_metrics_list: list[QueryMetrics]) -> dict:
+    """
+    Aggregate metrics across multiple queries.
+
+    Args:
+        query_metrics_list: List of QueryMetrics for individual queries
+
+    Returns:
+        Dictionary with mean and std for each metric
+    """
+    if not query_metrics_list:
+        return {}
+
+    all_k_values = set()
+    for qm in query_metrics_list:
+        all_k_values.update(qm.precision_at_k.keys())
+        all_k_values.update(qm.recall_at_k.keys())
+        all_k_values.update(qm.ndcg_at_k.keys())
+
+    aggregated = {}
+
+    for k in sorted(all_k_values):
+        precision_values = [
+            qm.precision_at_k.get(k, 0.0) for qm in query_metrics_list
+        ]
+        recall_values = [qm.recall_at_k.get(k, 0.0) for qm in query_metrics_list]
+        ndcg_values = [qm.ndcg_at_k.get(k, 0.0) for qm in query_metrics_list]
+
+        aggregated[f"precision@{k}"] = {
+            "mean": float(np.mean(precision_values)),
+            "std": float(np.std(precision_values)),
+        }
+        aggregated[f"recall@{k}"] = {
+            "mean": float(np.mean(recall_values)),
+            "std": float(np.std(recall_values)),
+        }
+        aggregated[f"ndcg@{k}"] = {
+            "mean": float(np.mean(ndcg_values)),
+            "std": float(np.std(ndcg_values)),
+        }
+
+    mrr_values = [qm.mrr for qm in query_metrics_list]
+    aggregated["mrr"] = {
+        "mean": float(np.mean(mrr_values)),
+        "std": float(np.std(mrr_values)),
+    }
+
+    similarity_values = [qm.semantic_similarity for qm in query_metrics_list]
+    if any(v > 0 for v in similarity_values):
+        aggregated["semantic_similarity"] = {
+            "mean": float(np.mean(similarity_values)),
+            "std": float(np.std(similarity_values)),
+        }
+
+    diversity_values = [qm.diversity for qm in query_metrics_list]
+    if any(v > 0 for v in diversity_values):
+        aggregated["diversity"] = {
+            "mean": float(np.mean(diversity_values)),
+            "std": float(np.std(diversity_values)),
+        }
+
+    return aggregated
+

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,0 +1,530 @@
+"""
+Tests for the retrieval quality evaluation framework.
+
+Tests cover:
+- Retrieval metrics computation
+- Ground truth builder functionality
+- Evaluation runner operations
+"""
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, "./")
+
+from evaluation.retrieval_metrics import (
+    RetrievalMetrics,
+    QueryMetrics,
+    precision_at_k,
+    recall_at_k,
+    mean_reciprocal_rank,
+    ndcg_at_k,
+    dcg_at_k,
+    cosine_similarity,
+    semantic_similarity,
+    diversity_score,
+    aggregate_metrics,
+)
+from evaluation.ground_truth_builder import (
+    GroundTruthBuilder,
+    GroundTruthDataset,
+    RelevanceLabel,
+    RelevanceAnnotation,
+)
+from evaluation.eval_runner import (
+    EvaluationRunner,
+    EvaluationConfig,
+    EvaluationReport,
+    RetrievalResult,
+    compare_evaluations,
+    generate_comparison_report,
+)
+
+
+class TestPrecisionAtK:
+    """Tests for precision_at_k metric."""
+
+    def test_perfect_precision(self):
+        retrieved = ["a", "b", "c", "d", "e"]
+        relevant = ["a", "b", "c", "d", "e"]
+        assert precision_at_k(retrieved, relevant, 5) == 1.0
+
+    def test_zero_precision(self):
+        retrieved = ["a", "b", "c"]
+        relevant = ["x", "y", "z"]
+        assert precision_at_k(retrieved, relevant, 3) == 0.0
+
+    def test_partial_precision(self):
+        retrieved = ["a", "b", "c", "d"]
+        relevant = ["a", "c"]
+        assert precision_at_k(retrieved, relevant, 4) == 0.5
+
+    def test_precision_at_1(self):
+        retrieved = ["a", "b", "c"]
+        relevant = ["a"]
+        assert precision_at_k(retrieved, relevant, 1) == 1.0
+
+    def test_precision_with_k_larger_than_retrieved(self):
+        retrieved = ["a", "b"]
+        relevant = ["a", "b", "c"]
+        assert precision_at_k(retrieved, relevant, 5) == 0.4
+
+    def test_precision_k_zero(self):
+        retrieved = ["a", "b"]
+        relevant = ["a"]
+        assert precision_at_k(retrieved, relevant, 0) == 0.0
+
+
+class TestRecallAtK:
+    """Tests for recall_at_k metric."""
+
+    def test_perfect_recall(self):
+        retrieved = ["a", "b", "c", "d", "e"]
+        relevant = ["a", "b", "c"]
+        assert recall_at_k(retrieved, relevant, 5) == 1.0
+
+    def test_zero_recall(self):
+        retrieved = ["x", "y", "z"]
+        relevant = ["a", "b", "c"]
+        assert recall_at_k(retrieved, relevant, 3) == 0.0
+
+    def test_partial_recall(self):
+        retrieved = ["a", "b", "c", "d"]
+        relevant = ["a", "c", "e", "f"]
+        assert recall_at_k(retrieved, relevant, 4) == 0.5
+
+    def test_recall_with_empty_relevant(self):
+        retrieved = ["a", "b"]
+        relevant = []
+        assert recall_at_k(retrieved, relevant, 2) == 0.0
+
+    def test_recall_k_zero(self):
+        retrieved = ["a", "b"]
+        relevant = ["a"]
+        assert recall_at_k(retrieved, relevant, 0) == 0.0
+
+
+class TestMRR:
+    """Tests for mean_reciprocal_rank metric."""
+
+    def test_first_position(self):
+        retrieved = ["a", "b", "c"]
+        relevant = ["a"]
+        assert mean_reciprocal_rank(retrieved, relevant) == 1.0
+
+    def test_second_position(self):
+        retrieved = ["x", "a", "b"]
+        relevant = ["a"]
+        assert mean_reciprocal_rank(retrieved, relevant) == 0.5
+
+    def test_third_position(self):
+        retrieved = ["x", "y", "a"]
+        relevant = ["a"]
+        assert abs(mean_reciprocal_rank(retrieved, relevant) - 1 / 3) < 1e-6
+
+    def test_no_relevant(self):
+        retrieved = ["x", "y", "z"]
+        relevant = ["a"]
+        assert mean_reciprocal_rank(retrieved, relevant) == 0.0
+
+    def test_multiple_relevant(self):
+        retrieved = ["x", "a", "b"]
+        relevant = ["a", "b"]
+        assert mean_reciprocal_rank(retrieved, relevant) == 0.5
+
+
+class TestNDCG:
+    """Tests for NDCG metric."""
+
+    def test_perfect_ndcg(self):
+        retrieved = ["a", "b", "c"]
+        relevant = ["a", "b", "c"]
+        assert ndcg_at_k(retrieved, relevant, 3) == 1.0
+
+    def test_zero_ndcg(self):
+        retrieved = ["x", "y", "z"]
+        relevant = ["a", "b", "c"]
+        assert ndcg_at_k(retrieved, relevant, 3) == 0.0
+
+    def test_partial_ndcg(self):
+        retrieved = ["a", "x", "b", "y"]
+        relevant = ["a", "b", "c"]
+        ndcg = ndcg_at_k(retrieved, relevant, 4)
+        assert 0 < ndcg < 1
+
+    def test_ndcg_with_graded_relevance(self):
+        retrieved = ["a", "b", "c"]
+        relevant = ["a", "b", "c"]
+        relevance_scores = {"a": 3.0, "b": 2.0, "c": 1.0}
+        ndcg = ndcg_at_k(retrieved, relevant, 3, relevance_scores)
+        assert ndcg == 1.0
+
+    def test_dcg_calculation(self):
+        retrieved = ["a", "b"]
+        relevant = ["a", "b"]
+        dcg = dcg_at_k(retrieved, relevant, 2)
+        assert dcg > 0
+
+
+class TestCosineSimilarity:
+    """Tests for cosine_similarity function."""
+
+    def test_identical_vectors(self):
+        vec = [1.0, 2.0, 3.0]
+        assert abs(cosine_similarity(vec, vec) - 1.0) < 1e-6
+
+    def test_orthogonal_vectors(self):
+        vec1 = [1.0, 0.0]
+        vec2 = [0.0, 1.0]
+        assert abs(cosine_similarity(vec1, vec2)) < 1e-6
+
+    def test_opposite_vectors(self):
+        vec1 = [1.0, 1.0]
+        vec2 = [-1.0, -1.0]
+        assert abs(cosine_similarity(vec1, vec2) + 1.0) < 1e-6
+
+    def test_zero_vector(self):
+        vec1 = [0.0, 0.0]
+        vec2 = [1.0, 1.0]
+        assert cosine_similarity(vec1, vec2) == 0.0
+
+
+class TestSemanticSimilarity:
+    """Tests for semantic_similarity function."""
+
+    def test_high_similarity(self):
+        query = [1.0, 0.0, 0.0]
+        results = [[0.9, 0.1, 0.0], [0.8, 0.2, 0.0]]
+        sim = semantic_similarity(query, results)
+        assert sim > 0.9
+
+    def test_low_similarity(self):
+        query = [1.0, 0.0, 0.0]
+        results = [[0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+        sim = semantic_similarity(query, results)
+        assert sim < 0.1
+
+    def test_empty_results(self):
+        query = [1.0, 0.0, 0.0]
+        results = []
+        assert semantic_similarity(query, results) == 0.0
+
+
+class TestDiversityScore:
+    """Tests for diversity_score function."""
+
+    def test_identical_results(self):
+        embeddings = [[1.0, 0.0], [1.0, 0.0], [1.0, 0.0]]
+        assert diversity_score(embeddings) < 0.1
+
+    def test_diverse_results(self):
+        embeddings = [[1.0, 0.0], [0.0, 1.0], [-1.0, 0.0]]
+        div = diversity_score(embeddings)
+        assert div > 0.5
+
+    def test_single_result(self):
+        embeddings = [[1.0, 0.0]]
+        assert diversity_score(embeddings) == 0.0
+
+
+class TestRetrievalMetrics:
+    """Tests for RetrievalMetrics class."""
+
+    def test_compute_all_metrics(self):
+        metrics = RetrievalMetrics(k_values=[1, 3, 5])
+        result = metrics.compute_all_metrics(
+            query="test query",
+            retrieved_ids=["a", "b", "c", "d", "e"],
+            relevant_ids=["a", "c", "e"],
+        )
+        assert isinstance(result, QueryMetrics)
+        assert result.query == "test query"
+        assert 1 in result.precision_at_k
+        assert result.mrr > 0
+
+    def test_with_embeddings(self):
+        metrics = RetrievalMetrics()
+        query_emb = [1.0, 0.0, 0.0]
+        result_embs = [[0.9, 0.1, 0.0], [0.8, 0.2, 0.0]]
+        result = metrics.compute_all_metrics(
+            query="test",
+            retrieved_ids=["a", "b"],
+            relevant_ids=["a"],
+            query_embedding=query_emb,
+            result_embeddings=result_embs,
+        )
+        assert result.semantic_similarity > 0
+        assert result.diversity >= 0
+
+
+class TestAggregateMetrics:
+    """Tests for aggregate_metrics function."""
+
+    def test_aggregate_multiple_queries(self):
+        metrics_list = [
+            QueryMetrics(
+                query="q1",
+                precision_at_k={1: 1.0, 3: 0.67},
+                recall_at_k={1: 0.5, 3: 1.0},
+                mrr=1.0,
+                ndcg_at_k={1: 1.0, 3: 0.9},
+            ),
+            QueryMetrics(
+                query="q2",
+                precision_at_k={1: 0.0, 3: 0.33},
+                recall_at_k={1: 0.0, 3: 0.5},
+                mrr=0.5,
+                ndcg_at_k={1: 0.0, 3: 0.5},
+            ),
+        ]
+        aggregated = aggregate_metrics(metrics_list)
+        assert "precision@1" in aggregated
+        assert "mrr" in aggregated
+        assert "mean" in aggregated["precision@1"]
+        assert "std" in aggregated["precision@1"]
+
+    def test_aggregate_empty_list(self):
+        assert aggregate_metrics([]) == {}
+
+
+class TestGroundTruthBuilder:
+    """Tests for GroundTruthBuilder class."""
+
+    def test_add_annotation(self):
+        builder = GroundTruthBuilder("test_dataset")
+        builder.add_annotation(
+            query="test query",
+            document_id="doc1",
+            document_title="Test Doc",
+            document_content="Test content",
+            label=RelevanceLabel.RELEVANT,
+        )
+        assert len(builder.dataset.annotations) == 1
+        assert builder.dataset.annotations[0].label == RelevanceLabel.RELEVANT
+
+    def test_get_relevant_ids(self):
+        builder = GroundTruthBuilder("test")
+        builder.add_annotation(
+            query="q1",
+            document_id="d1",
+            document_title="D1",
+            document_content="C1",
+            label=RelevanceLabel.HIGHLY_RELEVANT,
+        )
+        builder.add_annotation(
+            query="q1",
+            document_id="d2",
+            document_title="D2",
+            document_content="C2",
+            label=RelevanceLabel.NOT_RELEVANT,
+        )
+        relevant = builder.dataset.get_relevant_ids("q1")
+        assert "d1" in relevant
+        assert "d2" not in relevant
+
+    def test_get_relevance_scores(self):
+        builder = GroundTruthBuilder("test")
+        builder.add_annotation(
+            query="q1",
+            document_id="d1",
+            document_title="D1",
+            document_content="C1",
+            label=RelevanceLabel.HIGHLY_RELEVANT,
+        )
+        scores = builder.dataset.get_relevance_scores("q1")
+        assert scores["d1"] == 3.0
+
+    def test_save_and_load(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            filepath = os.path.join(tmpdir, "test_gt.json")
+
+            builder = GroundTruthBuilder("test_dataset", "Test description")
+            builder.add_annotation(
+                query="q1",
+                document_id="d1",
+                document_title="D1",
+                document_content="C1",
+                label=RelevanceLabel.RELEVANT,
+            )
+            builder.save(filepath)
+
+            loaded = GroundTruthBuilder.load(filepath)
+            assert loaded.dataset.name == "test_dataset"
+            assert len(loaded.dataset.annotations) == 1
+
+    def test_export_and_import(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            filepath = os.path.join(tmpdir, "export.json")
+
+            builder = GroundTruthBuilder("test")
+            builder.add_annotation(
+                query="q1",
+                document_id="d1",
+                document_title="D1",
+                document_content="C1",
+                label=RelevanceLabel.RELEVANT,
+            )
+            builder.export_for_sharing(filepath)
+
+            imported = GroundTruthBuilder.import_from_sharing_format(filepath)
+            assert len(imported.dataset.annotations) == 1
+
+    def test_get_statistics(self):
+        builder = GroundTruthBuilder("test")
+        builder.add_annotation(
+            query="q1",
+            document_id="d1",
+            document_title="D1",
+            document_content="C1",
+            label=RelevanceLabel.RELEVANT,
+        )
+        builder.add_annotation(
+            query="q1",
+            document_id="d2",
+            document_title="D2",
+            document_content="C2",
+            label=RelevanceLabel.NOT_RELEVANT,
+        )
+        stats = builder.get_statistics()
+        assert stats["total_annotations"] == 2
+        assert stats["unique_queries"] == 1
+
+
+class TestEvaluationRunner:
+    """Tests for EvaluationRunner class."""
+
+    @pytest.fixture
+    def sample_ground_truth(self):
+        builder = GroundTruthBuilder("test_gt")
+        builder.add_annotation(
+            query="What is Python?",
+            document_id="doc1",
+            document_title="Python Programming",
+            document_content="Python is a programming language",
+            label=RelevanceLabel.HIGHLY_RELEVANT,
+        )
+        builder.add_annotation(
+            query="What is Python?",
+            document_id="doc2",
+            document_title="Snake Info",
+            document_content="Python is also a snake",
+            label=RelevanceLabel.RELEVANT,
+        )
+        return builder.dataset
+
+    @pytest.fixture
+    def sample_config(self):
+        return EvaluationConfig(
+            name="test_eval",
+            k_values=[1, 3],
+            compute_semantic_similarity=False,
+            compute_diversity=False,
+        )
+
+    def test_evaluate_single(self, sample_ground_truth, sample_config):
+        runner = EvaluationRunner(
+            ground_truth=sample_ground_truth, config=sample_config
+        )
+        result = RetrievalResult(
+            query="What is Python?",
+            retrieved_ids=["doc1", "doc3", "doc2"],
+        )
+        metrics = runner.evaluate_single(result)
+        assert metrics.precision_at_k[1] == 1.0
+        assert metrics.mrr == 1.0
+
+    def test_evaluate_batch(self, sample_ground_truth, sample_config):
+        runner = EvaluationRunner(
+            ground_truth=sample_ground_truth, config=sample_config
+        )
+        results = [
+            RetrievalResult(
+                query="What is Python?",
+                retrieved_ids=["doc1", "doc2"],
+            ),
+        ]
+        report = runner.evaluate_batch(results)
+        assert isinstance(report, EvaluationReport)
+        assert report.num_queries == 1
+
+    def test_save_report(self, sample_ground_truth, sample_config):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = EvaluationConfig(
+                name="test_eval",
+                k_values=[1, 3],
+                output_dir=tmpdir,
+            )
+            runner = EvaluationRunner(
+                ground_truth=sample_ground_truth, config=config
+            )
+            results = [
+                RetrievalResult(
+                    query="What is Python?",
+                    retrieved_ids=["doc1"],
+                ),
+            ]
+            report = runner.evaluate_batch(results)
+            filepath = runner.save_report(report)
+            assert os.path.exists(filepath)
+
+
+class TestCompareEvaluations:
+    """Tests for evaluation comparison functions."""
+
+    def test_compare_evaluations(self):
+        reports = [
+            EvaluationReport(
+                config=EvaluationConfig(name="config_a"),
+                ground_truth_name="gt",
+                num_queries=10,
+                aggregated_metrics={
+                    "precision@1": {"mean": 0.8, "std": 0.1},
+                    "mrr": {"mean": 0.9, "std": 0.05},
+                },
+            ),
+            EvaluationReport(
+                config=EvaluationConfig(name="config_b"),
+                ground_truth_name="gt",
+                num_queries=10,
+                aggregated_metrics={
+                    "precision@1": {"mean": 0.7, "std": 0.15},
+                    "mrr": {"mean": 0.85, "std": 0.08},
+                },
+            ),
+        ]
+        comparison = compare_evaluations(reports)
+        assert "config_a" in comparison["reports"]
+        assert "config_b" in comparison["reports"]
+        assert comparison["best_per_metric"]["precision@1"] == "config_a"
+
+    def test_generate_comparison_report(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            reports = [
+                EvaluationReport(
+                    config=EvaluationConfig(name="config_a"),
+                    ground_truth_name="gt",
+                    num_queries=10,
+                    aggregated_metrics={
+                        "precision@1": {"mean": 0.8, "std": 0.1},
+                    },
+                ),
+            ]
+            output_path = os.path.join(tmpdir, "comparison.json")
+            generate_comparison_report(reports, output_path)
+            assert os.path.exists(output_path)
+
+
+class TestRelevanceLabel:
+    """Tests for RelevanceLabel enum."""
+
+    def test_label_scores(self):
+        assert RelevanceLabel.HIGHLY_RELEVANT.score == 3.0
+        assert RelevanceLabel.RELEVANT.score == 2.0
+        assert RelevanceLabel.PARTIALLY_RELEVANT.score == 1.0
+        assert RelevanceLabel.NOT_RELEVANT.score == 0.0
+

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -1,0 +1,559 @@
+"""
+Tests for the hallucination detection module.
+
+Tests cover:
+- Claim extraction and verification
+- NLI adapter functionality
+- Factuality scoring
+"""
+
+import asyncio
+import json
+import os
+import sys
+import tempfile
+
+import pytest
+
+sys.path.insert(0, "./")
+
+from verification.claim_verifier import (
+    ClaimVerifier,
+    ClaimVerification,
+    VerificationResult,
+    VerificationVerdict,
+    EvidenceMatch,
+)
+from verification.factuality_scorer import (
+    FactualityScorer,
+    FactualityScore,
+    DialogueFactuality,
+    TurnFactuality,
+    aggregate_factuality_scores,
+)
+from verification.nli_adapter import (
+    NLIAdapter,
+    NLIResult,
+    NLIPrediction,
+    MockNLIAdapter,
+    create_nli_adapter,
+)
+
+
+class TestVerificationVerdict:
+    """Tests for VerificationVerdict enum."""
+
+    def test_is_factual(self):
+        assert VerificationVerdict.SUPPORTED.is_factual is True
+        assert VerificationVerdict.REFUTED.is_factual is False
+        assert VerificationVerdict.NOT_ENOUGH_INFO.is_factual is False
+
+
+class TestEvidenceMatch:
+    """Tests for EvidenceMatch model."""
+
+    def test_create_evidence_match(self):
+        match = EvidenceMatch(
+            document_title="Test Title",
+            document_content="Test content",
+            relevance_score=0.9,
+            entailment_score=0.8,
+            url="https://example.com",
+        )
+        assert match.document_title == "Test Title"
+        assert match.relevance_score == 0.9
+
+
+class TestClaimVerification:
+    """Tests for ClaimVerification model."""
+
+    def test_create_verification(self):
+        verification = ClaimVerification(
+            claim="The sky is blue.",
+            evidence=[],
+            verdict=VerificationVerdict.SUPPORTED,
+            confidence=0.95,
+        )
+        assert verification.claim == "The sky is blue."
+        assert verification.verdict == VerificationVerdict.SUPPORTED
+
+
+class TestVerificationResult:
+    """Tests for VerificationResult model."""
+
+    def test_compute_overall_all_supported(self):
+        result = VerificationResult(
+            utterance="Test utterance",
+            claims=["claim1", "claim2"],
+            verifications=[
+                ClaimVerification(
+                    claim="claim1",
+                    evidence=[],
+                    verdict=VerificationVerdict.SUPPORTED,
+                    confidence=0.9,
+                ),
+                ClaimVerification(
+                    claim="claim2",
+                    evidence=[],
+                    verdict=VerificationVerdict.SUPPORTED,
+                    confidence=0.85,
+                ),
+            ],
+        )
+        result.compute_overall()
+        assert result.overall_verdict == VerificationVerdict.SUPPORTED
+        assert result.factuality_ratio == 1.0
+
+    def test_compute_overall_with_refuted(self):
+        result = VerificationResult(
+            utterance="Test utterance",
+            claims=["claim1", "claim2"],
+            verifications=[
+                ClaimVerification(
+                    claim="claim1",
+                    evidence=[],
+                    verdict=VerificationVerdict.SUPPORTED,
+                    confidence=0.9,
+                ),
+                ClaimVerification(
+                    claim="claim2",
+                    evidence=[],
+                    verdict=VerificationVerdict.REFUTED,
+                    confidence=0.85,
+                ),
+            ],
+        )
+        result.compute_overall()
+        assert result.overall_verdict == VerificationVerdict.REFUTED
+        assert result.factuality_ratio == 0.5
+
+    def test_compute_overall_empty(self):
+        result = VerificationResult(
+            utterance="Test",
+            claims=[],
+            verifications=[],
+        )
+        result.compute_overall()
+        assert result.overall_verdict == VerificationVerdict.NOT_ENOUGH_INFO
+        assert result.factuality_ratio == 0.0
+
+
+class TestClaimVerifier:
+    """Tests for ClaimVerifier class."""
+
+    def test_simple_claim_extraction(self):
+        verifier = ClaimVerifier()
+        claims = verifier._simple_claim_extraction(
+            "Python is a programming language. It was created by Guido van Rossum."
+        )
+        assert len(claims) == 2
+        assert "Python is a programming language" in claims[0]
+
+    def test_simple_claim_extraction_removes_questions(self):
+        verifier = ClaimVerifier()
+        claims = verifier._simple_claim_extraction(
+            "Python is great. What do you think? It is popular."
+        )
+        assert not any("?" in claim for claim in claims)
+
+    def test_keyword_overlap_score(self):
+        verifier = ClaimVerifier()
+        score = verifier._keyword_overlap_score(
+            "Python is a programming language",
+            "Python is a popular programming language used worldwide",
+        )
+        assert score > 0.5
+
+    def test_keyword_overlap_score_no_overlap(self):
+        verifier = ClaimVerifier()
+        score = verifier._keyword_overlap_score(
+            "Python is a programming language",
+            "Java coffee beans are delicious",
+        )
+        assert score < 0.3
+
+    @pytest.mark.asyncio
+    async def test_verify_claim_with_mock_nli(self):
+        mock_nli = MockNLIAdapter(
+            default_prediction=NLIPrediction.ENTAILMENT, default_confidence=0.9
+        )
+        verifier = ClaimVerifier(nli_adapter=mock_nli, entailment_threshold=0.7)
+
+        evidence = [
+            {
+                "title": "Python",
+                "content": "Python is a high-level programming language.",
+                "url": "https://python.org",
+            }
+        ]
+
+        result = await verifier.verify_claim(
+            "Python is a programming language.", evidence
+        )
+
+        assert result.verdict == VerificationVerdict.SUPPORTED
+        assert result.confidence >= 0.7
+
+    @pytest.mark.asyncio
+    async def test_verify_utterance(self):
+        verifier = ClaimVerifier()
+
+        evidence = [
+            {
+                "title": "Python Programming",
+                "content": "Python is a popular programming language created by Guido van Rossum.",
+            }
+        ]
+
+        result = await verifier.verify_utterance(
+            utterance="Python is a programming language. It was created by Guido.",
+            evidence_list=evidence,
+        )
+
+        assert isinstance(result, VerificationResult)
+        assert len(result.claims) > 0
+        assert len(result.verifications) == len(result.claims)
+
+    @pytest.mark.asyncio
+    async def test_verify_with_existing_claims(self):
+        verifier = ClaimVerifier()
+
+        existing_claims = ["Python is a programming language."]
+        evidence = [
+            {
+                "title": "Python",
+                "content": "Python is a programming language.",
+            }
+        ]
+
+        result = await verifier.verify_utterance(
+            utterance="Python is great!",
+            evidence_list=evidence,
+            existing_claims=existing_claims,
+        )
+
+        assert result.claims == existing_claims
+
+
+class TestNLIResult:
+    """Tests for NLIResult model."""
+
+    def test_confidence_entailment(self):
+        result = NLIResult(
+            premise="test",
+            hypothesis="test",
+            prediction=NLIPrediction.ENTAILMENT,
+            entailment_prob=0.9,
+            contradiction_prob=0.05,
+            neutral_prob=0.05,
+        )
+        assert result.confidence == 0.9
+
+    def test_confidence_contradiction(self):
+        result = NLIResult(
+            premise="test",
+            hypothesis="test",
+            prediction=NLIPrediction.CONTRADICTION,
+            entailment_prob=0.05,
+            contradiction_prob=0.9,
+            neutral_prob=0.05,
+        )
+        assert result.confidence == 0.9
+
+
+class TestMockNLIAdapter:
+    """Tests for MockNLIAdapter class."""
+
+    @pytest.mark.asyncio
+    async def test_default_prediction(self):
+        adapter = MockNLIAdapter(
+            default_prediction=NLIPrediction.NEUTRAL, default_confidence=0.8
+        )
+        result = await adapter.predict("premise", "hypothesis")
+        assert result.prediction == NLIPrediction.NEUTRAL
+
+    @pytest.mark.asyncio
+    async def test_set_response(self):
+        adapter = MockNLIAdapter()
+        adapter.set_response(
+            "specific hypothesis", NLIPrediction.ENTAILMENT, confidence=0.95
+        )
+        result = await adapter.predict("any premise", "specific hypothesis")
+        assert result.prediction == NLIPrediction.ENTAILMENT
+        assert result.entailment_prob == 0.95
+
+    @pytest.mark.asyncio
+    async def test_batch_predict(self):
+        adapter = MockNLIAdapter(default_prediction=NLIPrediction.ENTAILMENT)
+        pairs = [("p1", "h1"), ("p2", "h2"), ("p3", "h3")]
+        results = await adapter.predict_batch(pairs)
+        assert len(results) == 3
+        assert all(r.prediction == NLIPrediction.ENTAILMENT for r in results)
+
+
+class TestCreateNLIAdapter:
+    """Tests for create_nli_adapter factory."""
+
+    def test_create_mock_adapter(self):
+        adapter = create_nli_adapter(use_mock=True)
+        assert isinstance(adapter, MockNLIAdapter)
+
+    def test_create_real_adapter(self):
+        adapter = create_nli_adapter(use_mock=False)
+        assert isinstance(adapter, NLIAdapter)
+
+
+class TestFactualityScore:
+    """Tests for FactualityScore model."""
+
+    def test_from_verification_result(self):
+        result = VerificationResult(
+            utterance="Test",
+            claims=["c1", "c2", "c3"],
+            verifications=[
+                ClaimVerification(
+                    claim="c1",
+                    evidence=[],
+                    verdict=VerificationVerdict.SUPPORTED,
+                    confidence=0.9,
+                ),
+                ClaimVerification(
+                    claim="c2",
+                    evidence=[],
+                    verdict=VerificationVerdict.REFUTED,
+                    confidence=0.8,
+                ),
+                ClaimVerification(
+                    claim="c3",
+                    evidence=[],
+                    verdict=VerificationVerdict.NOT_ENOUGH_INFO,
+                    confidence=0.7,
+                ),
+            ],
+        )
+        result.compute_overall()
+
+        score = FactualityScore.from_verification_result(result, "test_id")
+        assert score.total_claims == 3
+        assert score.supported_claims == 1
+        assert score.refuted_claims == 1
+        assert score.uncertain_claims == 1
+        assert abs(score.factuality_ratio - 1 / 3) < 0.01
+
+
+class TestDialogueFactuality:
+    """Tests for DialogueFactuality model."""
+
+    def test_add_turn(self):
+        dialogue = DialogueFactuality(dialogue_id="test_dialogue")
+
+        turn = TurnFactuality(
+            turn_id=0,
+            user_utterance="Hello",
+            agent_utterance="Hi there!",
+            score=FactualityScore(
+                response_id="t0",
+                total_claims=2,
+                supported_claims=2,
+                refuted_claims=0,
+                uncertain_claims=0,
+                factuality_ratio=1.0,
+                weighted_score=0.9,
+                confidence=0.85,
+            ),
+            verifications=[],
+        )
+
+        dialogue.add_turn(turn)
+        assert len(dialogue.turns) == 1
+        assert dialogue.total_claims == 2
+        assert dialogue.overall_score == 1.0
+
+
+class TestFactualityScorer:
+    """Tests for FactualityScorer class."""
+
+    def test_score_response(self):
+        scorer = FactualityScorer(dialogue_id="test")
+
+        result = VerificationResult(
+            utterance="Test response",
+            claims=["claim1"],
+            verifications=[
+                ClaimVerification(
+                    claim="claim1",
+                    evidence=[],
+                    verdict=VerificationVerdict.SUPPORTED,
+                    confidence=0.9,
+                )
+            ],
+        )
+        result.compute_overall()
+
+        score = scorer.score_response(result, "Test input")
+        assert score.total_claims == 1
+        assert score.factuality_ratio == 1.0
+        assert scorer.get_current_score() == 1.0
+
+    def test_get_statistics(self):
+        scorer = FactualityScorer(dialogue_id="test")
+
+        for i in range(3):
+            result = VerificationResult(
+                utterance=f"Response {i}",
+                claims=[f"claim{i}"],
+                verifications=[
+                    ClaimVerification(
+                        claim=f"claim{i}",
+                        evidence=[],
+                        verdict=VerificationVerdict.SUPPORTED,
+                        confidence=0.8,
+                    )
+                ],
+            )
+            result.compute_overall()
+            scorer.score_response(result, f"Input {i}")
+
+        stats = scorer.get_statistics()
+        assert stats["num_turns"] == 3
+        assert stats["total_claims"] == 3
+        assert stats["overall_score"] == 1.0
+
+    def test_get_problematic_claims(self):
+        scorer = FactualityScorer(dialogue_id="test")
+
+        result = VerificationResult(
+            utterance="Test",
+            claims=["good claim", "bad claim"],
+            verifications=[
+                ClaimVerification(
+                    claim="good claim",
+                    evidence=[],
+                    verdict=VerificationVerdict.SUPPORTED,
+                    confidence=0.9,
+                ),
+                ClaimVerification(
+                    claim="bad claim",
+                    evidence=[],
+                    verdict=VerificationVerdict.REFUTED,
+                    confidence=0.85,
+                ),
+            ],
+        )
+        result.compute_overall()
+        scorer.score_response(result, "Input")
+
+        problematic = scorer.get_problematic_claims()
+        assert len(problematic) == 1
+        assert problematic[0]["claim"] == "bad claim"
+
+    def test_save_and_load(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            filepath = os.path.join(tmpdir, "factuality.json")
+
+            scorer = FactualityScorer(dialogue_id="test")
+            result = VerificationResult(
+                utterance="Test",
+                claims=["claim1"],
+                verifications=[
+                    ClaimVerification(
+                        claim="claim1",
+                        evidence=[],
+                        verdict=VerificationVerdict.SUPPORTED,
+                        confidence=0.9,
+                    )
+                ],
+            )
+            result.compute_overall()
+            scorer.score_response(result, "Input")
+            scorer.save(filepath)
+
+            loaded = FactualityScorer.load(filepath)
+            assert loaded.dialogue_id == "test"
+            assert len(loaded.dialogue.turns) == 1
+
+    def test_generate_report(self):
+        scorer = FactualityScorer(dialogue_id="test")
+
+        result = VerificationResult(
+            utterance="Test response",
+            claims=["claim1"],
+            verifications=[
+                ClaimVerification(
+                    claim="claim1",
+                    evidence=[],
+                    verdict=VerificationVerdict.SUPPORTED,
+                    confidence=0.9,
+                )
+            ],
+        )
+        result.compute_overall()
+        scorer.score_response(result, "Input")
+
+        report = scorer.generate_report()
+        assert "Factuality Report" in report
+        assert "test" in report
+
+
+class TestAggregateFactualityScores:
+    """Tests for aggregate_factuality_scores function."""
+
+    def test_aggregate_multiple_scorers(self):
+        scorers = []
+        for i in range(3):
+            scorer = FactualityScorer(dialogue_id=f"dialogue_{i}")
+            result = VerificationResult(
+                utterance=f"Response {i}",
+                claims=[f"claim{i}"],
+                verifications=[
+                    ClaimVerification(
+                        claim=f"claim{i}",
+                        evidence=[],
+                        verdict=VerificationVerdict.SUPPORTED,
+                        confidence=0.8,
+                    )
+                ],
+            )
+            result.compute_overall()
+            scorer.score_response(result, f"Input {i}")
+            scorers.append(scorer)
+
+        aggregated = aggregate_factuality_scores(scorers)
+        assert aggregated["num_dialogues"] == 3
+        assert aggregated["total_claims"] == 3
+        assert aggregated["overall_factuality"] == 1.0
+
+    def test_aggregate_empty_list(self):
+        assert aggregate_factuality_scores([]) == {}
+
+
+class TestIntegration:
+    """Integration tests for verification pipeline."""
+
+    @pytest.mark.asyncio
+    async def test_full_verification_pipeline(self):
+        mock_nli = MockNLIAdapter(
+            default_prediction=NLIPrediction.ENTAILMENT, default_confidence=0.85
+        )
+        verifier = ClaimVerifier(nli_adapter=mock_nli)
+        scorer = FactualityScorer(dialogue_id="integration_test")
+
+        evidence = [
+            {
+                "title": "Python",
+                "content": "Python is a high-level programming language created by Guido van Rossum in 1991.",
+            }
+        ]
+
+        result = await verifier.verify_utterance(
+            utterance="Python is a programming language. It was created by Guido van Rossum.",
+            evidence_list=evidence,
+        )
+
+        score = scorer.score_response(result, "Tell me about Python")
+
+        assert score.total_claims > 0
+        assert scorer.get_current_score() > 0
+        stats = scorer.get_statistics()
+        assert stats["num_turns"] == 1
+

--- a/verification/README.md
+++ b/verification/README.md
@@ -1,0 +1,193 @@
+# Hallucination Detection Module
+
+A post-hoc verification module for detecting and scoring hallucinations in WikiChat responses.
+
+## Overview
+
+This module provides tools for:
+- Extracting verifiable claims from agent utterances
+- Verifying claims against retrieved evidence using NLI models
+- Tracking factuality scores across dialogue sessions
+- Generating factuality reports
+
+## Installation
+
+The verification module uses dependencies already included in WikiChat:
+- `pydantic` for data validation
+
+Optional dependencies for NLI-based verification:
+- `transformers` for HuggingFace NLI models
+
+## Usage
+
+### Basic Claim Verification
+
+```python
+import asyncio
+from verification.claim_verifier import ClaimVerifier
+from verification.nli_adapter import create_nli_adapter
+
+# Create verifier with NLI support
+nli_adapter = create_nli_adapter(
+    model_name="microsoft/deberta-v3-base-mnli-fever-anli",
+    device="cpu",  # or "cuda" for GPU
+)
+verifier = ClaimVerifier(nli_adapter=nli_adapter)
+
+# Prepare evidence from retrieval
+evidence = [
+    {
+        "title": "Python (programming language)",
+        "content": "Python is a high-level programming language created by Guido van Rossum.",
+        "url": "https://en.wikipedia.org/wiki/Python_(programming_language)",
+    }
+]
+
+# Verify an utterance
+result = asyncio.run(verifier.verify_utterance(
+    utterance="Python is a programming language created by Guido van Rossum in 1991.",
+    evidence_list=evidence,
+))
+
+print(f"Overall verdict: {result.overall_verdict}")
+print(f"Factuality ratio: {result.factuality_ratio:.2%}")
+for v in result.verifications:
+    print(f"  - {v.claim}: {v.verdict} ({v.confidence:.2%})")
+```
+
+### Integration with WikiChat Pipeline
+
+```python
+from verification.claim_verifier import ClaimVerifier
+from verification.nli_adapter import MockNLIAdapter  # or NLIAdapter for real NLI
+
+# Use with dialogue turn data
+async def verify_turn(dialogue_turn):
+    verifier = ClaimVerifier(nli_adapter=MockNLIAdapter())
+    
+    result = await verifier.verify_dialogue_turn(
+        agent_utterance=dialogue_turn.agent_utterance,
+        filtered_search_results=dialogue_turn.filtered_search_results,
+        llm_claims=dialogue_turn.llm_claims,  # Reuse existing claims
+    )
+    return result
+```
+
+### Factuality Scoring and Tracking
+
+```python
+from verification.factuality_scorer import FactualityScorer
+from verification.claim_verifier import ClaimVerifier
+
+# Create scorer for a dialogue session
+scorer = FactualityScorer(dialogue_id="session_123")
+
+# For each turn, score the response
+for turn in dialogue_turns:
+    verification_result = await verifier.verify_utterance(
+        utterance=turn.agent_utterance,
+        evidence_list=evidence,
+    )
+    
+    score = scorer.score_response(
+        verification_result=verification_result,
+        user_utterance=turn.user_utterance,
+    )
+    print(f"Turn factuality: {score.factuality_ratio:.2%}")
+
+# Get overall statistics
+stats = scorer.get_statistics()
+print(f"Overall dialogue factuality: {stats['overall_score']:.2%}")
+print(f"Total claims: {stats['total_claims']}")
+
+# Get problematic claims for review
+problematic = scorer.get_problematic_claims()
+for claim in problematic:
+    print(f"[{claim['verdict']}] {claim['claim']}")
+
+# Save factuality data
+scorer.save("factuality_logs/session_123.json")
+
+# Generate human-readable report
+print(scorer.generate_report())
+```
+
+### Using Different NLI Models
+
+```python
+from verification.nli_adapter import NLIAdapter, MockNLIAdapter
+
+# Use a real NLI model
+real_adapter = NLIAdapter(
+    model_name="microsoft/deberta-v3-base-mnli-fever-anli",
+    device="cuda",  # or "cpu"
+    batch_size=16,
+)
+
+# For testing without model loading
+mock_adapter = MockNLIAdapter(
+    default_prediction=NLIPrediction.NEUTRAL,
+    default_confidence=0.8,
+)
+
+# Configure specific responses for testing
+mock_adapter.set_response(
+    "Python was created by Guido",
+    NLIPrediction.ENTAILMENT,
+    confidence=0.95,
+)
+```
+
+### Aggregating Across Multiple Dialogues
+
+```python
+from verification.factuality_scorer import aggregate_factuality_scores
+
+scorers = [scorer1, scorer2, scorer3]  # FactualityScorer instances
+aggregated = aggregate_factuality_scores(scorers)
+
+print(f"Total dialogues: {aggregated['num_dialogues']}")
+print(f"Overall factuality: {aggregated['overall_factuality']:.2%}")
+print(f"Average per dialogue: {aggregated['average_score_per_dialogue']:.2%}")
+```
+
+## Verification Verdicts
+
+| Verdict | Description | Interpretation |
+|---------|-------------|----------------|
+| SUPPORTED | Claim is entailed by evidence | Factual |
+| REFUTED | Claim contradicts evidence | Hallucination |
+| NOT_ENOUGH_INFO | Insufficient evidence | Uncertain |
+
+## File Structure
+
+```
+verification/
+    __init__.py           # Module exports
+    claim_verifier.py     # Claim extraction and verification
+    factuality_scorer.py  # Scoring and tracking
+    nli_adapter.py        # NLI model interface
+    README.md             # This file
+```
+
+## NLI Models
+
+Recommended models for verification:
+- `microsoft/deberta-v3-base-mnli-fever-anli` (default, best accuracy)
+- `facebook/bart-large-mnli` (good balance of speed/accuracy)
+- `cross-encoder/nli-deberta-v3-small` (faster, smaller)
+
+## Testing
+
+```bash
+pytest tests/test_verification.py -v
+```
+
+## Research Applications
+
+This module enables:
+- **Factuality Metrics**: Quantifiable hallucination rates per response
+- **Self-Verification**: Flag uncertain statements for user review
+- **Ablation Studies**: Measure impact of different pipeline configurations
+- **Benchmark Evaluation**: Compare factuality across models/settings
+

--- a/verification/__init__.py
+++ b/verification/__init__.py
@@ -1,0 +1,38 @@
+"""
+Hallucination Detection Module for WikiChat.
+
+This module provides tools for post-hoc verification of generated claims
+against retrieved evidence, including:
+- Claim extraction and verification
+- NLI-based entailment checking
+- Factuality scoring and tracking
+"""
+
+from verification.claim_verifier import (
+    ClaimVerifier,
+    ClaimVerification,
+    VerificationVerdict,
+)
+from verification.factuality_scorer import (
+    FactualityScorer,
+    FactualityScore,
+    DialogueFactuality,
+)
+from verification.nli_adapter import (
+    NLIAdapter,
+    NLIResult,
+    NLIPrediction,
+)
+
+__all__ = [
+    "ClaimVerifier",
+    "ClaimVerification",
+    "VerificationVerdict",
+    "FactualityScorer",
+    "FactualityScore",
+    "DialogueFactuality",
+    "NLIAdapter",
+    "NLIResult",
+    "NLIPrediction",
+]
+

--- a/verification/claim_verifier.py
+++ b/verification/claim_verifier.py
@@ -1,0 +1,373 @@
+"""
+Claim extraction and verification against retrieved evidence.
+
+Provides tools for extracting claims from agent utterances and verifying
+them against search results.
+"""
+
+import asyncio
+import re
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class VerificationVerdict(str, Enum):
+    """Verdict for a claim verification."""
+
+    SUPPORTED = "SUPPORTED"
+    REFUTED = "REFUTED"
+    NOT_ENOUGH_INFO = "NOT_ENOUGH_INFO"
+
+    @property
+    def is_factual(self) -> bool:
+        """Check if the verdict indicates factuality."""
+        return self == VerificationVerdict.SUPPORTED
+
+
+class EvidenceMatch(BaseModel):
+    """A piece of evidence matched to a claim."""
+
+    document_title: str = Field(..., description="Title of the source document")
+    document_content: str = Field(..., description="Content of the evidence")
+    relevance_score: float = Field(
+        0.0, ge=0.0, le=1.0, description="Relevance score"
+    )
+    entailment_score: float = Field(
+        0.0, ge=0.0, le=1.0, description="Entailment score from NLI"
+    )
+    url: Optional[str] = Field(None, description="URL of the source")
+
+
+class ClaimVerification(BaseModel):
+    """Result of verifying a single claim."""
+
+    claim: str = Field(..., description="The claim being verified")
+    evidence: list[EvidenceMatch] = Field(
+        default_factory=list, description="Evidence used for verification"
+    )
+    verdict: VerificationVerdict = Field(
+        ..., description="Verification verdict"
+    )
+    confidence: float = Field(
+        0.0, ge=0.0, le=1.0, description="Confidence in the verdict"
+    )
+    explanation: Optional[str] = Field(
+        None, description="Explanation for the verdict"
+    )
+
+
+class VerificationResult(BaseModel):
+    """Complete verification result for an agent utterance."""
+
+    utterance: str = Field(..., description="The original agent utterance")
+    claims: list[str] = Field(default_factory=list, description="Extracted claims")
+    verifications: list[ClaimVerification] = Field(
+        default_factory=list, description="Verification results per claim"
+    )
+    overall_verdict: VerificationVerdict = Field(
+        VerificationVerdict.NOT_ENOUGH_INFO,
+        description="Overall verification verdict",
+    )
+    factuality_ratio: float = Field(
+        0.0, ge=0.0, le=1.0, description="Ratio of supported claims"
+    )
+
+    def compute_overall(self) -> None:
+        """Compute overall verdict and factuality ratio."""
+        if not self.verifications:
+            self.overall_verdict = VerificationVerdict.NOT_ENOUGH_INFO
+            self.factuality_ratio = 0.0
+            return
+
+        supported = sum(
+            1
+            for v in self.verifications
+            if v.verdict == VerificationVerdict.SUPPORTED
+        )
+        refuted = sum(
+            1
+            for v in self.verifications
+            if v.verdict == VerificationVerdict.REFUTED
+        )
+
+        self.factuality_ratio = supported / len(self.verifications)
+
+        if refuted > 0:
+            self.overall_verdict = VerificationVerdict.REFUTED
+        elif supported == len(self.verifications):
+            self.overall_verdict = VerificationVerdict.SUPPORTED
+        else:
+            self.overall_verdict = VerificationVerdict.NOT_ENOUGH_INFO
+
+
+class ClaimVerifier:
+    """
+    Verifier for extracting and checking claims against evidence.
+
+    Uses NLI models to verify entailment between claims and retrieved evidence.
+    """
+
+    def __init__(
+        self,
+        nli_adapter: Optional["NLIAdapter"] = None,
+        llm_engine: Optional[str] = None,
+        entailment_threshold: float = 0.7,
+        contradiction_threshold: float = 0.7,
+    ):
+        """
+        Initialize the claim verifier.
+
+        Args:
+            nli_adapter: NLI adapter for entailment checking
+            llm_engine: LLM engine for claim extraction (if not using existing claims)
+            entailment_threshold: Threshold for SUPPORTED verdict
+            contradiction_threshold: Threshold for REFUTED verdict
+        """
+        self.nli_adapter = nli_adapter
+        self.llm_engine = llm_engine
+        self.entailment_threshold = entailment_threshold
+        self.contradiction_threshold = contradiction_threshold
+
+    async def extract_claims(self, utterance: str) -> list[str]:
+        """
+        Extract verifiable claims from an utterance.
+
+        Args:
+            utterance: The agent utterance
+
+        Returns:
+            List of extracted claims
+        """
+        if self.llm_engine is None:
+            return self._simple_claim_extraction(utterance)
+
+        try:
+            from chainlite import llm_generation_chain
+        except ImportError:
+            return self._simple_claim_extraction(utterance)
+
+        prompt = f"""Extract factual claims from the following text. Each claim should be:
+1. A complete, self-contained statement
+2. Verifiable (not an opinion or subjective statement)
+3. Atomic (one fact per claim)
+
+Text: {utterance}
+
+List each claim on a separate line, starting with "- ". 
+If there are no verifiable claims, respond with "None"."""
+
+        chain = llm_generation_chain(
+            template_file=None,
+            engine=self.llm_engine,
+            max_tokens=500,
+        )
+
+        response = await chain.ainvoke({"text": prompt})
+
+        claims = []
+        for line in response.strip().split("\n"):
+            line = line.strip()
+            if line.startswith("- "):
+                claim = line[2:].strip()
+                if claim and claim.lower() != "none":
+                    claims.append(claim)
+
+        return claims if claims else self._simple_claim_extraction(utterance)
+
+    def _simple_claim_extraction(self, utterance: str) -> list[str]:
+        """
+        Simple sentence-based claim extraction fallback.
+
+        Args:
+            utterance: The agent utterance
+
+        Returns:
+            List of sentences as claims
+        """
+        utterance = re.sub(r"\[\d+\]", "", utterance)
+
+        sentences = re.split(r"(?<=[.!?])\s+", utterance.strip())
+
+        claims = []
+        for sentence in sentences:
+            sentence = sentence.strip()
+            if len(sentence) > 10 and not sentence.endswith("?"):
+                claims.append(sentence)
+
+        return claims
+
+    async def verify_claim(
+        self,
+        claim: str,
+        evidence_list: list[dict],
+    ) -> ClaimVerification:
+        """
+        Verify a single claim against evidence.
+
+        Args:
+            claim: The claim to verify
+            evidence_list: List of evidence dicts with title, content, url
+
+        Returns:
+            ClaimVerification result
+        """
+        evidence_matches = []
+        max_entailment = 0.0
+        max_contradiction = 0.0
+
+        for evidence in evidence_list:
+            content = evidence.get("content", "")
+            if not content:
+                continue
+
+            if self.nli_adapter is not None:
+                nli_result = await self.nli_adapter.predict(
+                    premise=content, hypothesis=claim
+                )
+
+                entailment_score = nli_result.entailment_prob
+                contradiction_score = nli_result.contradiction_prob
+            else:
+                entailment_score = self._keyword_overlap_score(claim, content)
+                contradiction_score = 0.0
+
+            max_entailment = max(max_entailment, entailment_score)
+            max_contradiction = max(max_contradiction, contradiction_score)
+
+            if entailment_score > 0.3:
+                evidence_matches.append(
+                    EvidenceMatch(
+                        document_title=evidence.get("title", "Unknown"),
+                        document_content=content[:500],
+                        relevance_score=evidence.get("score", 0.0),
+                        entailment_score=entailment_score,
+                        url=evidence.get("url"),
+                    )
+                )
+
+        if max_entailment >= self.entailment_threshold:
+            verdict = VerificationVerdict.SUPPORTED
+            confidence = max_entailment
+        elif max_contradiction >= self.contradiction_threshold:
+            verdict = VerificationVerdict.REFUTED
+            confidence = max_contradiction
+        else:
+            verdict = VerificationVerdict.NOT_ENOUGH_INFO
+            confidence = 1.0 - max(max_entailment, max_contradiction)
+
+        return ClaimVerification(
+            claim=claim,
+            evidence=evidence_matches,
+            verdict=verdict,
+            confidence=confidence,
+        )
+
+    def _keyword_overlap_score(self, claim: str, evidence: str) -> float:
+        """
+        Simple keyword overlap score for fallback verification.
+
+        Args:
+            claim: The claim text
+            evidence: The evidence text
+
+        Returns:
+            Overlap score between 0 and 1
+        """
+        claim_words = set(claim.lower().split())
+        evidence_words = set(evidence.lower().split())
+
+        stopwords = {
+            "the", "a", "an", "is", "are", "was", "were", "be", "been",
+            "being", "have", "has", "had", "do", "does", "did", "will",
+            "would", "could", "should", "may", "might", "must", "shall",
+            "can", "to", "of", "in", "for", "on", "with", "at", "by",
+            "from", "as", "into", "through", "during", "before", "after",
+            "above", "below", "between", "under", "again", "further",
+            "then", "once", "here", "there", "when", "where", "why",
+            "how", "all", "each", "few", "more", "most", "other", "some",
+            "such", "no", "nor", "not", "only", "own", "same", "so",
+            "than", "too", "very", "just", "but", "and", "or", "if",
+            "because", "until", "while", "this", "that", "these", "those",
+        }
+
+        claim_words = claim_words - stopwords
+        evidence_words = evidence_words - stopwords
+
+        if not claim_words:
+            return 0.0
+
+        overlap = len(claim_words.intersection(evidence_words))
+        return overlap / len(claim_words)
+
+    async def verify_utterance(
+        self,
+        utterance: str,
+        evidence_list: list[dict],
+        existing_claims: Optional[list[str]] = None,
+    ) -> VerificationResult:
+        """
+        Verify all claims in an utterance.
+
+        Args:
+            utterance: The agent utterance
+            evidence_list: List of evidence dicts
+            existing_claims: Pre-extracted claims (optional)
+
+        Returns:
+            Complete VerificationResult
+        """
+        if existing_claims is not None:
+            claims = existing_claims
+        else:
+            claims = await self.extract_claims(utterance)
+
+        verifications = []
+        for claim in claims:
+            verification = await self.verify_claim(claim, evidence_list)
+            verifications.append(verification)
+
+        result = VerificationResult(
+            utterance=utterance,
+            claims=claims,
+            verifications=verifications,
+        )
+        result.compute_overall()
+
+        return result
+
+    async def verify_dialogue_turn(
+        self,
+        agent_utterance: str,
+        filtered_search_results: list,
+        llm_claims: Optional[list[str]] = None,
+    ) -> VerificationResult:
+        """
+        Verify claims in a dialogue turn using WikiChat's data structures.
+
+        Args:
+            agent_utterance: The agent's response
+            filtered_search_results: List of SearchResultBlock objects
+            llm_claims: Pre-extracted claims from WikiChat pipeline
+
+        Returns:
+            VerificationResult for the turn
+        """
+        evidence_list = []
+        for result in filtered_search_results:
+            evidence_list.append(
+                {
+                    "title": getattr(result, "full_title", ""),
+                    "content": getattr(result, "content", ""),
+                    "url": getattr(result, "url", None),
+                    "score": getattr(result, "probability_score", 0.0),
+                }
+            )
+
+        return await self.verify_utterance(
+            utterance=agent_utterance,
+            evidence_list=evidence_list,
+            existing_claims=llm_claims,
+        )
+

--- a/verification/factuality_scorer.py
+++ b/verification/factuality_scorer.py
@@ -1,0 +1,407 @@
+"""
+Factuality scoring and tracking for dialogue responses.
+
+Provides aggregate factuality metrics and historical tracking across
+dialogue turns.
+"""
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+from verification.claim_verifier import (
+    ClaimVerification,
+    VerificationResult,
+    VerificationVerdict,
+)
+
+
+class FactualityScore(BaseModel):
+    """Factuality score for a single response."""
+
+    response_id: str = Field(..., description="Unique identifier for the response")
+    timestamp: datetime = Field(
+        default_factory=datetime.now, description="Score timestamp"
+    )
+    total_claims: int = Field(0, description="Total number of claims")
+    supported_claims: int = Field(0, description="Number of supported claims")
+    refuted_claims: int = Field(0, description="Number of refuted claims")
+    uncertain_claims: int = Field(0, description="Number of uncertain claims")
+    factuality_ratio: float = Field(
+        0.0, ge=0.0, le=1.0, description="Ratio of supported claims"
+    )
+    weighted_score: float = Field(
+        0.0, ge=0.0, le=1.0, description="Weighted factuality score"
+    )
+    confidence: float = Field(
+        0.0, ge=0.0, le=1.0, description="Average confidence in verifications"
+    )
+
+    @classmethod
+    def from_verification_result(
+        cls, result: VerificationResult, response_id: str
+    ) -> "FactualityScore":
+        """
+        Create a factuality score from a verification result.
+
+        Args:
+            result: The verification result
+            response_id: Unique response identifier
+
+        Returns:
+            FactualityScore instance
+        """
+        supported = sum(
+            1
+            for v in result.verifications
+            if v.verdict == VerificationVerdict.SUPPORTED
+        )
+        refuted = sum(
+            1
+            for v in result.verifications
+            if v.verdict == VerificationVerdict.REFUTED
+        )
+        uncertain = sum(
+            1
+            for v in result.verifications
+            if v.verdict == VerificationVerdict.NOT_ENOUGH_INFO
+        )
+
+        total = len(result.verifications)
+        factuality_ratio = supported / total if total > 0 else 0.0
+
+        if total > 0:
+            weighted_sum = 0.0
+            for v in result.verifications:
+                if v.verdict == VerificationVerdict.SUPPORTED:
+                    weighted_sum += v.confidence
+                elif v.verdict == VerificationVerdict.REFUTED:
+                    weighted_sum -= v.confidence * 0.5
+            weighted_score = max(0.0, min(1.0, (weighted_sum / total + 1) / 2))
+        else:
+            weighted_score = 0.5
+
+        avg_confidence = (
+            sum(v.confidence for v in result.verifications) / total
+            if total > 0
+            else 0.0
+        )
+
+        return cls(
+            response_id=response_id,
+            total_claims=total,
+            supported_claims=supported,
+            refuted_claims=refuted,
+            uncertain_claims=uncertain,
+            factuality_ratio=factuality_ratio,
+            weighted_score=weighted_score,
+            confidence=avg_confidence,
+        )
+
+
+class TurnFactuality(BaseModel):
+    """Factuality information for a dialogue turn."""
+
+    turn_id: int = Field(..., description="Turn number in the dialogue")
+    user_utterance: str = Field(..., description="User's message")
+    agent_utterance: str = Field(..., description="Agent's response")
+    score: FactualityScore = Field(..., description="Factuality score")
+    verifications: list[ClaimVerification] = Field(
+        default_factory=list, description="Individual claim verifications"
+    )
+
+
+class DialogueFactuality(BaseModel):
+    """Factuality tracking for an entire dialogue."""
+
+    dialogue_id: str = Field(..., description="Unique dialogue identifier")
+    start_time: datetime = Field(
+        default_factory=datetime.now, description="Dialogue start time"
+    )
+    turns: list[TurnFactuality] = Field(
+        default_factory=list, description="Per-turn factuality"
+    )
+    overall_score: float = Field(
+        0.0, ge=0.0, le=1.0, description="Overall dialogue factuality"
+    )
+    total_claims: int = Field(0, description="Total claims across dialogue")
+    supported_claims: int = Field(0, description="Total supported claims")
+    refuted_claims: int = Field(0, description="Total refuted claims")
+
+    def add_turn(self, turn: TurnFactuality) -> None:
+        """Add a turn and update aggregate metrics."""
+        self.turns.append(turn)
+        self._update_aggregates()
+
+    def _update_aggregates(self) -> None:
+        """Update aggregate metrics from all turns."""
+        self.total_claims = sum(t.score.total_claims for t in self.turns)
+        self.supported_claims = sum(t.score.supported_claims for t in self.turns)
+        self.refuted_claims = sum(t.score.refuted_claims for t in self.turns)
+
+        if self.total_claims > 0:
+            self.overall_score = self.supported_claims / self.total_claims
+        else:
+            self.overall_score = 0.0
+
+
+@dataclass
+class FactualityScorer:
+    """
+    Scorer for tracking and aggregating factuality across responses.
+
+    Provides methods for scoring individual responses and tracking
+    factuality across dialogue sessions.
+    """
+
+    dialogue_id: str
+    dialogue: DialogueFactuality = field(init=False)
+    _turn_counter: int = field(default=0, init=False)
+
+    def __post_init__(self):
+        self.dialogue = DialogueFactuality(dialogue_id=self.dialogue_id)
+
+    def score_response(
+        self,
+        verification_result: VerificationResult,
+        user_utterance: str,
+    ) -> FactualityScore:
+        """
+        Score a single response and add to dialogue history.
+
+        Args:
+            verification_result: Verification result for the response
+            user_utterance: The user's input
+
+        Returns:
+            FactualityScore for the response
+        """
+        response_id = f"{self.dialogue_id}_turn_{self._turn_counter}"
+        score = FactualityScore.from_verification_result(
+            verification_result, response_id
+        )
+
+        turn = TurnFactuality(
+            turn_id=self._turn_counter,
+            user_utterance=user_utterance,
+            agent_utterance=verification_result.utterance,
+            score=score,
+            verifications=verification_result.verifications,
+        )
+
+        self.dialogue.add_turn(turn)
+        self._turn_counter += 1
+
+        return score
+
+    def get_current_score(self) -> float:
+        """Get the current overall factuality score."""
+        return self.dialogue.overall_score
+
+    def get_statistics(self) -> dict:
+        """
+        Get comprehensive statistics about dialogue factuality.
+
+        Returns:
+            Dictionary with factuality statistics
+        """
+        if not self.dialogue.turns:
+            return {
+                "dialogue_id": self.dialogue_id,
+                "num_turns": 0,
+                "overall_score": 0.0,
+                "total_claims": 0,
+                "claim_breakdown": {
+                    "supported": 0,
+                    "refuted": 0,
+                    "uncertain": 0,
+                },
+            }
+
+        scores = [t.score for t in self.dialogue.turns]
+
+        return {
+            "dialogue_id": self.dialogue_id,
+            "num_turns": len(self.dialogue.turns),
+            "overall_score": self.dialogue.overall_score,
+            "total_claims": self.dialogue.total_claims,
+            "claim_breakdown": {
+                "supported": self.dialogue.supported_claims,
+                "refuted": self.dialogue.refuted_claims,
+                "uncertain": sum(s.uncertain_claims for s in scores),
+            },
+            "per_turn_scores": [
+                {
+                    "turn": t.turn_id,
+                    "factuality_ratio": t.score.factuality_ratio,
+                    "weighted_score": t.score.weighted_score,
+                    "claims": t.score.total_claims,
+                }
+                for t in self.dialogue.turns
+            ],
+            "average_claims_per_turn": (
+                self.dialogue.total_claims / len(self.dialogue.turns)
+            ),
+            "average_confidence": sum(s.confidence for s in scores) / len(scores),
+        }
+
+    def get_problematic_claims(self) -> list[dict]:
+        """
+        Get all refuted or uncertain claims for review.
+
+        Returns:
+            List of problematic claims with context
+        """
+        problematic = []
+
+        for turn in self.dialogue.turns:
+            for v in turn.verifications:
+                if v.verdict != VerificationVerdict.SUPPORTED:
+                    problematic.append(
+                        {
+                            "turn_id": turn.turn_id,
+                            "claim": v.claim,
+                            "verdict": v.verdict.value,
+                            "confidence": v.confidence,
+                            "evidence_count": len(v.evidence),
+                            "context": turn.user_utterance,
+                        }
+                    )
+
+        return problematic
+
+    def save(self, output_path: str) -> None:
+        """
+        Save dialogue factuality data to file.
+
+        Args:
+            output_path: Path to save the data
+        """
+        path = Path(output_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(
+                self.dialogue.model_dump(mode="json"),
+                f,
+                indent=2,
+                default=str,
+            )
+
+    @classmethod
+    def load(cls, input_path: str) -> "FactualityScorer":
+        """
+        Load dialogue factuality data from file.
+
+        Args:
+            input_path: Path to the saved data
+
+        Returns:
+            FactualityScorer with loaded data
+        """
+        with open(input_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        dialogue = DialogueFactuality.model_validate(data)
+        scorer = cls(dialogue_id=dialogue.dialogue_id)
+        scorer.dialogue = dialogue
+        scorer._turn_counter = len(dialogue.turns)
+
+        return scorer
+
+    def generate_report(self) -> str:
+        """
+        Generate a human-readable factuality report.
+
+        Returns:
+            Formatted report string
+        """
+        stats = self.get_statistics()
+
+        lines = [
+            f"Factuality Report: {self.dialogue_id}",
+            "=" * 50,
+            "",
+            f"Number of Turns: {stats['num_turns']}",
+            f"Overall Factuality Score: {stats['overall_score']:.2%}",
+            "",
+            "Claim Breakdown:",
+            f"  Total Claims: {stats['total_claims']}",
+            f"  Supported: {stats['claim_breakdown']['supported']}",
+            f"  Refuted: {stats['claim_breakdown']['refuted']}",
+            f"  Uncertain: {stats['claim_breakdown']['uncertain']}",
+            "",
+        ]
+
+        if stats.get("per_turn_scores"):
+            lines.append("Per-Turn Scores:")
+            for turn_stat in stats["per_turn_scores"]:
+                lines.append(
+                    f"  Turn {turn_stat['turn']}: "
+                    f"{turn_stat['factuality_ratio']:.2%} "
+                    f"({turn_stat['claims']} claims)"
+                )
+
+        problematic = self.get_problematic_claims()
+        if problematic:
+            lines.extend(
+                [
+                    "",
+                    "Problematic Claims:",
+                    "-" * 40,
+                ]
+            )
+            for claim_info in problematic[:10]:
+                lines.append(
+                    f"  [{claim_info['verdict']}] {claim_info['claim'][:80]}..."
+                    if len(claim_info["claim"]) > 80
+                    else f"  [{claim_info['verdict']}] {claim_info['claim']}"
+                )
+
+        return "\n".join(lines)
+
+
+def aggregate_factuality_scores(scorers: list[FactualityScorer]) -> dict:
+    """
+    Aggregate factuality statistics across multiple dialogues.
+
+    Args:
+        scorers: List of FactualityScorer instances
+
+    Returns:
+        Aggregated statistics dictionary
+    """
+    if not scorers:
+        return {}
+
+    all_stats = [s.get_statistics() for s in scorers]
+
+    total_turns = sum(s["num_turns"] for s in all_stats)
+    total_claims = sum(s["total_claims"] for s in all_stats)
+    total_supported = sum(s["claim_breakdown"]["supported"] for s in all_stats)
+    total_refuted = sum(s["claim_breakdown"]["refuted"] for s in all_stats)
+    total_uncertain = sum(s["claim_breakdown"]["uncertain"] for s in all_stats)
+
+    overall_scores = [s["overall_score"] for s in all_stats if s["num_turns"] > 0]
+
+    return {
+        "num_dialogues": len(scorers),
+        "total_turns": total_turns,
+        "total_claims": total_claims,
+        "overall_factuality": total_supported / total_claims if total_claims > 0 else 0,
+        "claim_breakdown": {
+            "supported": total_supported,
+            "refuted": total_refuted,
+            "uncertain": total_uncertain,
+        },
+        "average_score_per_dialogue": (
+            sum(overall_scores) / len(overall_scores) if overall_scores else 0
+        ),
+        "min_score": min(overall_scores) if overall_scores else 0,
+        "max_score": max(overall_scores) if overall_scores else 0,
+    }
+

--- a/verification/nli_adapter.py
+++ b/verification/nli_adapter.py
@@ -1,0 +1,298 @@
+"""
+Natural Language Inference (NLI) adapter for entailment checking.
+
+Provides a unified interface for various NLI models including
+HuggingFace transformers-based models.
+"""
+
+import asyncio
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional, Union
+
+from pydantic import BaseModel, Field
+
+
+class NLIPrediction(str, Enum):
+    """NLI prediction labels."""
+
+    ENTAILMENT = "entailment"
+    CONTRADICTION = "contradiction"
+    NEUTRAL = "neutral"
+
+
+class NLIResult(BaseModel):
+    """Result from an NLI model prediction."""
+
+    premise: str = Field(..., description="The premise text")
+    hypothesis: str = Field(..., description="The hypothesis text")
+    prediction: NLIPrediction = Field(..., description="Predicted label")
+    entailment_prob: float = Field(
+        0.0, ge=0.0, le=1.0, description="Probability of entailment"
+    )
+    contradiction_prob: float = Field(
+        0.0, ge=0.0, le=1.0, description="Probability of contradiction"
+    )
+    neutral_prob: float = Field(
+        0.0, ge=0.0, le=1.0, description="Probability of neutral"
+    )
+
+    @property
+    def confidence(self) -> float:
+        """Get confidence of the predicted label."""
+        if self.prediction == NLIPrediction.ENTAILMENT:
+            return self.entailment_prob
+        elif self.prediction == NLIPrediction.CONTRADICTION:
+            return self.contradiction_prob
+        else:
+            return self.neutral_prob
+
+
+@dataclass
+class NLIAdapter:
+    """
+    Adapter for NLI models supporting entailment checking.
+
+    Provides a unified interface for various NLI backends including
+    HuggingFace transformers models.
+    """
+
+    model_name: str = "microsoft/deberta-v3-base-mnli-fever-anli"
+    device: str = "cpu"
+    batch_size: int = 8
+    _pipeline: Optional[object] = field(default=None, init=False)
+    _initialized: bool = field(default=False, init=False)
+
+    def _initialize(self) -> None:
+        """Initialize the NLI model."""
+        if self._initialized:
+            return
+
+        try:
+            from transformers import pipeline
+        except ImportError:
+            raise ImportError(
+                "transformers is required for NLI. "
+                "Install it with: pip install transformers"
+            )
+
+        self._pipeline = pipeline(
+            "text-classification",
+            model=self.model_name,
+            device=self.device if self.device != "cpu" else -1,
+            top_k=None,
+        )
+        self._initialized = True
+
+    def _parse_result(
+        self, premise: str, hypothesis: str, result: list[dict]
+    ) -> NLIResult:
+        """Parse pipeline result into NLIResult."""
+        probs = {
+            NLIPrediction.ENTAILMENT: 0.0,
+            NLIPrediction.CONTRADICTION: 0.0,
+            NLIPrediction.NEUTRAL: 0.0,
+        }
+
+        label_map = {
+            "ENTAILMENT": NLIPrediction.ENTAILMENT,
+            "CONTRADICTION": NLIPrediction.CONTRADICTION,
+            "NEUTRAL": NLIPrediction.NEUTRAL,
+            "entailment": NLIPrediction.ENTAILMENT,
+            "contradiction": NLIPrediction.CONTRADICTION,
+            "neutral": NLIPrediction.NEUTRAL,
+            "LABEL_0": NLIPrediction.CONTRADICTION,
+            "LABEL_1": NLIPrediction.NEUTRAL,
+            "LABEL_2": NLIPrediction.ENTAILMENT,
+        }
+
+        for item in result:
+            label = item.get("label", "")
+            score = item.get("score", 0.0)
+            if label in label_map:
+                probs[label_map[label]] = score
+
+        prediction = max(probs, key=probs.get)
+
+        return NLIResult(
+            premise=premise,
+            hypothesis=hypothesis,
+            prediction=prediction,
+            entailment_prob=probs[NLIPrediction.ENTAILMENT],
+            contradiction_prob=probs[NLIPrediction.CONTRADICTION],
+            neutral_prob=probs[NLIPrediction.NEUTRAL],
+        )
+
+    async def predict(self, premise: str, hypothesis: str) -> NLIResult:
+        """
+        Predict NLI relationship between premise and hypothesis.
+
+        Args:
+            premise: The premise (evidence) text
+            hypothesis: The hypothesis (claim) text
+
+        Returns:
+            NLIResult with prediction and probabilities
+        """
+        self._initialize()
+
+        input_text = f"{premise} [SEP] {hypothesis}"
+
+        loop = asyncio.get_event_loop()
+        result = await loop.run_in_executor(
+            None, lambda: self._pipeline(input_text)
+        )
+
+        return self._parse_result(premise, hypothesis, result)
+
+    async def predict_batch(
+        self, pairs: list[tuple[str, str]]
+    ) -> list[NLIResult]:
+        """
+        Batch predict NLI relationships.
+
+        Args:
+            pairs: List of (premise, hypothesis) tuples
+
+        Returns:
+            List of NLIResult objects
+        """
+        self._initialize()
+
+        inputs = [f"{p} [SEP] {h}" for p, h in pairs]
+
+        loop = asyncio.get_event_loop()
+        results = await loop.run_in_executor(
+            None, lambda: self._pipeline(inputs, batch_size=self.batch_size)
+        )
+
+        return [
+            self._parse_result(p, h, r) for (p, h), r in zip(pairs, results)
+        ]
+
+    def predict_sync(self, premise: str, hypothesis: str) -> NLIResult:
+        """
+        Synchronous prediction for non-async contexts.
+
+        Args:
+            premise: The premise text
+            hypothesis: The hypothesis text
+
+        Returns:
+            NLIResult with prediction
+        """
+        self._initialize()
+
+        input_text = f"{premise} [SEP] {hypothesis}"
+        result = self._pipeline(input_text)
+
+        return self._parse_result(premise, hypothesis, result)
+
+
+class MockNLIAdapter:
+    """
+    Mock NLI adapter for testing without model loading.
+
+    Returns configurable predictions for testing purposes.
+    """
+
+    def __init__(
+        self,
+        default_prediction: NLIPrediction = NLIPrediction.NEUTRAL,
+        default_confidence: float = 0.8,
+    ):
+        """
+        Initialize mock adapter.
+
+        Args:
+            default_prediction: Default prediction to return
+            default_confidence: Default confidence score
+        """
+        self.default_prediction = default_prediction
+        self.default_confidence = default_confidence
+        self._overrides: dict[str, NLIResult] = {}
+
+    def set_response(
+        self, hypothesis: str, prediction: NLIPrediction, confidence: float = 0.9
+    ) -> None:
+        """Set a specific response for a hypothesis."""
+        probs = {
+            NLIPrediction.ENTAILMENT: 0.1,
+            NLIPrediction.CONTRADICTION: 0.1,
+            NLIPrediction.NEUTRAL: 0.1,
+        }
+        probs[prediction] = confidence
+        remaining = 1.0 - confidence
+        for p in probs:
+            if p != prediction:
+                probs[p] = remaining / 2
+
+        self._overrides[hypothesis] = NLIResult(
+            premise="",
+            hypothesis=hypothesis,
+            prediction=prediction,
+            entailment_prob=probs[NLIPrediction.ENTAILMENT],
+            contradiction_prob=probs[NLIPrediction.CONTRADICTION],
+            neutral_prob=probs[NLIPrediction.NEUTRAL],
+        )
+
+    async def predict(self, premise: str, hypothesis: str) -> NLIResult:
+        """Return configured or default prediction."""
+        if hypothesis in self._overrides:
+            result = self._overrides[hypothesis]
+            return NLIResult(
+                premise=premise,
+                hypothesis=hypothesis,
+                prediction=result.prediction,
+                entailment_prob=result.entailment_prob,
+                contradiction_prob=result.contradiction_prob,
+                neutral_prob=result.neutral_prob,
+            )
+
+        probs = {
+            NLIPrediction.ENTAILMENT: 0.1,
+            NLIPrediction.CONTRADICTION: 0.1,
+            NLIPrediction.NEUTRAL: 0.1,
+        }
+        probs[self.default_prediction] = self.default_confidence
+
+        return NLIResult(
+            premise=premise,
+            hypothesis=hypothesis,
+            prediction=self.default_prediction,
+            entailment_prob=probs[NLIPrediction.ENTAILMENT],
+            contradiction_prob=probs[NLIPrediction.CONTRADICTION],
+            neutral_prob=probs[NLIPrediction.NEUTRAL],
+        )
+
+    async def predict_batch(
+        self, pairs: list[tuple[str, str]]
+    ) -> list[NLIResult]:
+        """Batch predict using mock responses."""
+        return [await self.predict(p, h) for p, h in pairs]
+
+
+def create_nli_adapter(
+    model_name: Optional[str] = None,
+    use_mock: bool = False,
+    device: str = "cpu",
+) -> Union[NLIAdapter, MockNLIAdapter]:
+    """
+    Factory function to create an NLI adapter.
+
+    Args:
+        model_name: HuggingFace model name (None for default)
+        use_mock: Whether to use mock adapter (for testing)
+        device: Device to run model on
+
+    Returns:
+        NLIAdapter or MockNLIAdapter instance
+    """
+    if use_mock:
+        return MockNLIAdapter()
+
+    if model_name is None:
+        model_name = "microsoft/deberta-v3-base-mnli-fever-anli"
+
+    return NLIAdapter(model_name=model_name, device=device)
+


### PR DESCRIPTION
## Summary

This PR introduces two new purely additive modules for research and evaluation purposes.

### 1. Retrieval Quality Evaluation Framework (`evaluation/`)

A comprehensive framework for evaluating retrieval quality:

- **`retrieval_metrics.py`**: Standard IR metrics implementation
  - Precision@K, Recall@K, MRR, NDCG
  - Semantic similarity (cosine similarity between query and results)
  - Diversity metrics (pairwise dissimilarity among results)

- **`ground_truth_builder.py`**: Tools for building evaluation datasets
  - Manual annotation support with graded relevance labels
  - LLM-assisted relevance labeling
  - Import/export for sharing datasets

- **`eval_runner.py`**: Batch evaluation and reporting
  - Evaluate retrieval results against ground truth
  - Generate comparison reports across configurations
  - Save detailed metrics to JSON

### 2. Hallucination Detection Module (`verification/`)

Post-hoc verification of generated claims against retrieved evidence:

- **`claim_verifier.py`**: Extract and verify claims
  - Simple and LLM-based claim extraction
  - Verification against retrieved evidence
  - Integration with WikiChat's `DialogueTurn` structure

- **`factuality_scorer.py`**: Track factuality across dialogues
  - Per-turn and aggregate factuality scores
  - Identify problematic claims for review
  - Generate human-readable reports

- **`nli_adapter.py`**: Unified NLI interface
  - Support for HuggingFace transformers models
  - Mock adapter for testing
  - Batch prediction support

## Why This Matters (Research Value)

- **Reproducibility**: Researchers can compare retrieval quality across configurations
- **Benchmarking**: Enable ablation studies with precise metrics
- **Factuality Tracking**: Quantifiable hallucination rates per response
- **Self-Verification**: Flag uncertain statements for review

## Zero Maintainer Risk

- All contributions are **purely additive** (new files/directories only)
- No modifications to existing files (`chatbot.py`, `retriever_api.py`, etc.)
- Uses existing patterns (Pydantic models, pytest, async patterns)
- Optional features (can be enabled/disabled via flags)
- Well-documented (README per module, comprehensive docstrings)

## Testing

pytest tests/test_evaluation.py tests/test_verification.py -v**Results**: 77 tests passing

## Files Added

| Module | Files |
|--------|-------|
| `evaluation/` | `__init__.py`, `retrieval_metrics.py`, `ground_truth_builder.py`, `eval_runner.py`, `README.md` |
| `verification/` | `__init__.py`, `claim_verifier.py`, `factuality_scorer.py`, `nli_adapter.py`, `README.md` |
| `tests/` | `test_evaluation.py`, `test_verification.py` |

## Authors
- Ireddi Rakshitha
- Devavarapu Yaswanth